### PR TITLE
Fix StreamingResultSet metadata methods

### DIFF
--- a/jdbc-slim/pom.xml
+++ b/jdbc-slim/pom.xml
@@ -206,7 +206,7 @@
                         </goals>
                         <configuration>
                             <addOutputDirectory>false</addOutputDirectory>
-                            <sourceDirectory>jdbc-driver/src/main/java</sourceDirectory>
+                            <sourceDirectory>jdbc-slim/src/main/java</sourceDirectory>
                             <outputDirectory>${project.build.directory}/delombok</outputDirectory>
                         </configuration>
                     </execution>

--- a/jdbc-slim/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
+++ b/jdbc-slim/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
@@ -190,6 +190,7 @@ public class DataCloudConnection implements Connection, AutoCloseable {
      * @return A {@link DataCloudResultSet} containing the query results.
      */
     public DataCloudResultSet getRowBasedResultSet(String queryId, long offset, long limit, RowBased.Mode mode) {
+        log.info("Get row-based result set. queryId={}, offset={}, limit={}, mode={}", queryId, offset, limit, mode);
         val iterator = RowBased.of(executor, queryId, offset, limit, mode);
         return StreamingResultSet.of(queryId, executor, iterator);
     }

--- a/jdbc-slim/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
+++ b/jdbc-slim/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
@@ -44,6 +44,7 @@ public class DataCloudStatement implements Statement {
     protected static final String NOT_SUPPORTED_IN_DATACLOUD_QUERY = "Write is not supported in Data Cloud query";
     protected static final String BATCH_EXECUTION_IS_NOT_SUPPORTED =
             "Batch execution is not supported in Data Cloud query";
+    protected static final String CHANGE_FETCH_DIRECTION_IS_NOT_SUPPORTED = "Changing fetch direction is not supported";
     private static final String QUERY_TIMEOUT = "queryTimeout";
     public static final int DEFAULT_QUERY_TIMEOUT = 3 * 60 * 60;
 
@@ -246,11 +247,14 @@ public class DataCloudStatement implements Statement {
     }
 
     @Override
-    public void setFetchDirection(int direction) {}
+    public void setFetchDirection(int direction) throws SQLException {
+        throw new DataCloudJDBCException(CHANGE_FETCH_DIRECTION_IS_NOT_SUPPORTED, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    }
 
     @Override
-    public int getFetchDirection() {
-        return ResultSet.FETCH_FORWARD;
+    public int getFetchDirection() throws SQLException {
+        assertQueryExecuted();
+        return resultSet.getFetchDirection();
     }
 
     @Override
@@ -262,13 +266,15 @@ public class DataCloudStatement implements Statement {
     }
 
     @Override
-    public int getResultSetConcurrency() {
-        return 0;
+    public int getResultSetConcurrency() throws SQLException {
+        assertQueryExecuted();
+        return resultSet.getConcurrency();
     }
 
     @Override
-    public int getResultSetType() {
-        return ResultSet.TYPE_FORWARD_ONLY;
+    public int getResultSetType() throws SQLException {
+        assertQueryExecuted();
+        return resultSet.getType();
     }
 
     @Override

--- a/jdbc-slim/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
+++ b/jdbc-slim/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
@@ -19,6 +19,7 @@ import com.salesforce.datacloud.jdbc.core.listener.QueryStatusListener;
 import com.salesforce.datacloud.jdbc.exception.QueryExceptionHandler;
 import com.salesforce.datacloud.jdbc.util.ArrowUtils;
 import com.salesforce.datacloud.jdbc.util.StreamUtilities;
+import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -136,5 +137,20 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
         public Stream<QueryResult> stream() {
             return Stream.empty();
         }
+    }
+
+    @Override
+    public int getType() {
+        return ResultSet.TYPE_FORWARD_ONLY;
+    }
+
+    @Override
+    public int getConcurrency() {
+        return ResultSet.CONCUR_READ_ONLY;
+    }
+
+    @Override
+    public int getFetchDirection() {
+        return ResultSet.FETCH_FORWARD;
     }
 }

--- a/jdbc-slim/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementFunctionalTest.java
+++ b/jdbc-slim/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementFunctionalTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
+import com.salesforce.datacloud.jdbc.hyper.HyperTestBase;
+import java.sql.ResultSet;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+public class DataCloudStatementFunctionalTest extends HyperTestBase {
+    @Test
+    @SneakyThrows
+    public void forwardAndReadOnly() {
+        assertWithStatement(statement -> {
+            val rs = statement.executeQuery("select 1");
+
+            assertThat(statement.getResultSetConcurrency()).isEqualTo(ResultSet.CONCUR_READ_ONLY);
+            assertThat(statement.getFetchDirection()).isEqualTo(ResultSet.FETCH_FORWARD);
+            assertThat(statement.getResultSetType()).isEqualTo(ResultSet.TYPE_FORWARD_ONLY);
+
+            assertThat(rs.getType()).isEqualTo(ResultSet.TYPE_FORWARD_ONLY);
+            assertThat(rs.getConcurrency()).isEqualTo(ResultSet.CONCUR_READ_ONLY);
+        });
+    }
+
+    private static final String EXECUTED_MESSAGE = "a query was not executed before attempting to access results";
+
+    @SneakyThrows
+    @Test
+    public void requiresExecutedResultSet() {
+        assertWithStatement(statement -> assertThatThrownBy(statement::getResultSetType)
+                .isInstanceOf(DataCloudJDBCException.class)
+                .hasMessage(EXECUTED_MESSAGE));
+
+        assertWithStatement(statement -> assertThatThrownBy(statement::getResultSetConcurrency)
+                .isInstanceOf(DataCloudJDBCException.class)
+                .hasMessage(EXECUTED_MESSAGE));
+
+        assertWithStatement(statement -> assertThatThrownBy(statement::getFetchDirection)
+                .isInstanceOf(DataCloudJDBCException.class)
+                .hasMessage(EXECUTED_MESSAGE));
+    }
+}

--- a/jdbc-slim/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementTest.java
+++ b/jdbc-slim/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementTest.java
@@ -65,13 +65,6 @@ public class DataCloudStatementTest extends HyperGrpcTestBase {
         statement = new DataCloudStatement(connection);
     }
 
-    @Test
-    @SneakyThrows
-    public void forwardOnly() {
-        assertThat(statement.getFetchDirection()).isEqualTo(ResultSet.FETCH_FORWARD);
-        assertThat(statement.getResultSetType()).isEqualTo(ResultSet.TYPE_FORWARD_ONLY);
-    }
-
     private static Stream<Executable> unsupportedBatchExecutes() {
         return Stream.of(
                 () -> statement.execute("", 1),

--- a/jdbc-slim/src/test/java/com/salesforce/datacloud/jdbc/core/partial/Page.java
+++ b/jdbc-slim/src/test/java/com/salesforce/datacloud/jdbc/core/partial/Page.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.core.partial;
+
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import lombok.Value;
+import lombok.val;
+
+@Value
+class Page {
+    long offset;
+    long limit;
+
+    /**
+     * Calculates some number of full pages of some limit with a final page making up the remainder of rows
+     * @param rows the total number of rows in the query result
+     * @param limit the total number of rows to be acquired in this page
+     * @return a stream of pages that can be mapped to
+     * {@link com.salesforce.datacloud.jdbc.core.DataCloudConnection#getRowBasedResultSet } calls
+     */
+    public static Stream<Page> stream(long rows, long limit) {
+        long baseSize = Math.min(rows, limit);
+        long fullPageCount = rows / baseSize;
+        long remainder = rows % baseSize;
+
+        val fullPages = LongStream.range(0, fullPageCount).mapToObj(i -> new Page(i * baseSize, baseSize));
+        return Stream.concat(
+                fullPages, remainder > 0 ? Stream.of(new Page(fullPageCount * baseSize, remainder)) : Stream.empty());
+    }
+}


### PR DESCRIPTION
 - Manually implemented `StreamingResultSet::getType`, `StreamingResultSet::getConcurrency`, and `StreamingResultSet::getFetchDirection` methods to return appropriate values that match how `StreamingResultSet` works.
 - Moved a file into the `jdbc-slim` module that must have been missed during a subtle merge conflict in #19 
 - Added some more test coverage for row-based pagination, specifically for `DataCloudPreparedStatement`
