### PR TITLE
disable gradle cache for release

### DIFF
--- a/.github/workflows/reusable-build-publish.yml
+++ b/.github/workflows/reusable-build-publish.yml
@@ -52,9 +52,12 @@ jobs:
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
           build-scan-terms-of-use-agree: "yes"
           gradle-version: "8.12"
+          cache-disabled: ${{ inputs.version != '' }}
       - name: Gradle build
         id: build
         run: gradle clean build
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
       - name: Publish on release
         id: publish
         if: ${{ inputs.publish && (success() || steps.build.outcome == 'success') }}

--- a/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
@@ -15,7 +15,10 @@ private val ci = object {
         else -> "$revision-SNAPSHOT"
     }
 
-    private val releaseVersion = System.getenv("RELEASE_VERSION")?.ifBlank { null }
+    private val releaseVersion = System.getenv("RELEASE_VERSION")?.ifBlank {
+        logger.lifecycle("env.RELEASE_VERSION not present, assuming snapshot")
+        null
+    }
 
     val isRelease = releaseVersion != null
 


### PR DESCRIPTION
disable gradle cache when a version is specified (release) to force recompilation