### PR TITLE
override versions for netty to resolve vulnerability

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("base-conventions")
     `java-library`
-//    id("com.diffplug.spotless")
+    id("com.diffplug.spotless")
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ com-fasterxml-jackson-core-jackson-databind = "2.18.0"
 com-google-guava-guava = "33.4.0-jre"
 okhttp3 = "4.12.0"
 protobuf = "3.25.5"
-grpc = "1.70.0"
+grpc = "1.71.0"
 jjwt = "0.12.6"
 javax-annotation-javax-annotation-api = "1.3.2"
 net-jodah-failsafe = "2.4.4"
@@ -23,7 +23,7 @@ plugin-com-google-protobuf = "0.9.4"
 plugin-com-gradleup-shadow = "8.3.6"
 plugin-freefair-lombok = "8.13"
 plugin-build-buf = "0.10.2"
-
+netty = "4.1.119.Final"
 
 [libraries]
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "com-fasterxml-jackson-core-jackson-databind" }
@@ -35,11 +35,9 @@ grpc-netty = { module = "io.grpc:grpc-netty", version.ref = "grpc" }
 grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
 grpc-protoc = { group = "io.grpc", name = "protoc-gen-grpc-java", version.ref = "grpc" }
-
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
 jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
 jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
-
 javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version.ref = "javax-annotation-javax-annotation-api" }
 failsafe = { module = "net.jodah:failsafe", version.ref = "net-jodah-failsafe" }
 apache-arrow-memory-netty = { module = "org.apache.arrow:arrow-memory-netty", version.ref = "arrow" }
@@ -59,13 +57,14 @@ mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf" }
+netty-common = { group = "io.netty", name = "netty-common", version.ref = "netty" }
+netty-handler = { group = "io.netty", name = "netty-handler", version.ref = "netty" }
 
 [bundles]
 arrow = ["apache-arrow-vector", "apache-arrow-memory-netty"]
 grpc = ["grpc-netty", "grpc-protobuf", "grpc-stub", "javax-annotation-api"]
 testing = ["junit-jupiter-base", "junit-jupiter-api", "junit-jupiter-engine", "junit-jupiter-params", "junit-platform-launcher", "assertj", "slf4j-simple"]
 mocking = ["mockito-inline", "mockito-junit-jupiter", "grpcmock", "okhttp3-mockwebserver"]
-
 
 [plugins]
 protobuf = { id = "com.google.protobuf", version.ref = "plugin-com-google-protobuf" }

--- a/jdbc-core/build.gradle.kts
+++ b/jdbc-core/build.gradle.kts
@@ -5,6 +5,16 @@ plugins {
 }
 
 dependencies {
+    constraints {
+        implementation(libs.netty.common) {
+            because("https://www.mend.io/vulnerability-database/CVE-2024-47535")
+        }
+
+        implementation(libs.netty.handler) {
+            because("https://www.mend.io/vulnerability-database/CVE-2025-24970")
+        }
+    }
+
     api(project(":jdbc-grpc"))
 
     implementation(libs.slf4j.api)

--- a/jdbc-grpc/build.gradle.kts
+++ b/jdbc-grpc/build.gradle.kts
@@ -4,11 +4,19 @@ plugins {
     id("java-conventions")
     id("publishing-conventions")
     id("com.google.osdetector")
+    id("com.diffplug.spotless")
     alias(libs.plugins.protobuf)
 }
 
 dependencies {
+    constraints {
+        implementation(libs.netty.common) {
+            because("https://www.mend.io/vulnerability-database/CVE-2024-47535")
+        }
+    }
+
     api(platform(libs.grpc.bom))
+
     implementation(libs.bundles.grpc)
 }
 


### PR DESCRIPTION
Looks like the version of netty that arrow 17 (which we can't update because of java 8 requirement) has some vulnerabilities:

- [[CVE-2024-47535] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')](https://ossindex.sonatype.org/vulnerability/CVE-2024-47535?component-type=maven&component-name=io.netty%2Fnetty-common&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0)
- [[CVE-2025-24970] CWE-20: Improper Input Validation](https://ossindex.sonatype.org/vulnerability/CVE-2025-24970?component-type=maven&component-name=io.netty%2Fnetty-handler&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0)
