### PR TITLE
build: Restore separate jdbc-proto artifact for better visibility

### DIFF
--- a/.github/workflows/reusable-build-publish.yml
+++ b/.github/workflows/reusable-build-publish.yml
@@ -57,10 +57,10 @@ jobs:
         run: |
           if [[ "${{ inputs.version }}" != "" ]]; then
             echo "Version specified, running clean build with no cache for ${{ inputs.version }}"
-            gradle clean build --no-build-cache --rerun-tasks
+            gradle clean check --no-build-cache --rerun-tasks
           else
             echo "No version specified, running normal build"
-            gradle clean build
+            gradle clean check 
           fi
         env:
           RELEASE_VERSION: ${{ inputs.version }}
@@ -77,6 +77,9 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signing_key }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.signing_pass }}
         run: gradle publishAllPublicationsToMavenCentralRepository --no-scan --no-configuration-cache
+      - name: Look at files in verification
+        if: ${{ failure() || steps.build.outcome == 'failure' || steps.publish.outcome == 'failure' }}
+        run: ls -lR verification
       - name: Upload hyper logs on failure
         if: ${{ failure() || steps.build.outcome == 'failure' || steps.publish.outcome == 'failure' }}
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ pom.xml.bak
 .gradle
 .hyper
 .kotlin
+bin

--- a/buildSrc/src/main/kotlin/hyper-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/hyper-conventions.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 val hyperApiVersion: String by project
-val hypzerZipPath = ".hyper/hyper-$hyperApiVersion.zip"
+val hyperZipPath = ".hyper/hyper-$hyperApiVersion.zip"
 
 tasks.register<de.undercouch.gradle.tasks.download.Download>("downloadHyper") {
     group = "hyper"
@@ -18,7 +18,7 @@ tasks.register<de.undercouch.gradle.tasks.download.Download>("downloadHyper") {
     val url = "$urlBase.$hyperApiVersion.zip"
 
     src(url)
-    dest(project.layout.projectDirectory.file(hypzerZipPath))
+    dest(project.layout.projectDirectory.file(hyperZipPath))
     overwrite(false)
 }
 
@@ -29,7 +29,7 @@ tasks.register<Copy>("extractHyper") {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     includeEmptyDirs = false
 
-    from(zipTree(project.layout.projectDirectory.file(hypzerZipPath))) {
+    from(zipTree(project.layout.projectDirectory.file(hyperZipPath))) {
         include("**/lib/hyper/hyperd")
         include("**/lib/hyper/hyperd.exe")
         include("**/lib/**/*.dylib")

--- a/buildSrc/src/main/kotlin/hyper-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/hyper-conventions.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 val hyperApiVersion: String by project
-val hyperZipName = "hyper-$hyperApiVersion.zip"
+val hypzerZipPath = ".hyper/hyper-$hyperApiVersion.zip"
 
 tasks.register<de.undercouch.gradle.tasks.download.Download>("downloadHyper") {
     group = "hyper"
@@ -18,7 +18,7 @@ tasks.register<de.undercouch.gradle.tasks.download.Download>("downloadHyper") {
     val url = "$urlBase.$hyperApiVersion.zip"
 
     src(url)
-    dest(project.layout.buildDirectory.file(hyperZipName))
+    dest(project.layout.projectDirectory.file(hypzerZipPath))
     overwrite(false)
 }
 
@@ -29,7 +29,7 @@ tasks.register<Copy>("extractHyper") {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     includeEmptyDirs = false
 
-    from(zipTree(project.layout.buildDirectory.file(hyperZipName))) {
+    from(zipTree(project.layout.projectDirectory.file(hypzerZipPath))) {
         include("**/lib/hyper/hyperd")
         include("**/lib/hyper/hyperd.exe")
         include("**/lib/**/*.dylib")

--- a/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
@@ -1,32 +1,13 @@
 plugins {
     id("base-conventions")
+    id("version-conventions")
     signing
     `maven-publish`
     id("dev.adamko.dev-publish")
 }
 
-val revision: String by project
-
 val mavenCentralRepoName = "MavenCentral"
-
-private val ci = object {
-    private val snapshotVersion = when (System.getenv("GITHUB_RUN_NUMBER")) {
-        null -> "$revision-LOCAL"
-        else -> "$revision-SNAPSHOT"
-    }
-
-    private val releaseVersion = System.getenv("RELEASE_VERSION")?.ifBlank {
-        logger.lifecycle("env.RELEASE_VERSION not present, assuming snapshot")
-        null
-    }
-
-    val isRelease = releaseVersion != null
-
-    val resolvedVersion = releaseVersion ?: snapshotVersion
-}
-
-group = "com.salesforce.datacloud"
-version = ci.resolvedVersion
+val isRelease = !System.getenv("RELEASE_VERSION").isNullOrBlank()
 
 signing {
     val signingPassword: String? by project
@@ -37,7 +18,7 @@ signing {
     }
 
     sign(publishing.publications)
-    setRequired { ci.isRelease }
+    setRequired { isRelease }
 }
 
 gradle.taskGraph.whenReady {
@@ -45,7 +26,7 @@ gradle.taskGraph.whenReady {
         .filterIsInstance<PublishToMavenRepository>()
         .any { it.repository?.name == mavenCentralRepoName }
 
-    signing.setRequired({ isPublishingToMavenCentral || ci.isRelease })
+    signing.setRequired({ isPublishingToMavenCentral || isRelease })
 
     tasks.withType<Sign> {
         val isPublishingToMavenCentralCustom = isPublishingToMavenCentral
@@ -68,7 +49,7 @@ publishing {
             name = mavenCentralRepoName
             val releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
             val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-            url = if (ci.isRelease) releasesRepoUrl else snapshotsRepoUrl
+            url = if (isRelease) releasesRepoUrl else snapshotsRepoUrl
             credentials {
                 username = System.getenv("OSSRH_USERNAME")
                 password = System.getenv("OSSRH_PASSWORD")

--- a/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
@@ -61,7 +61,6 @@ publishing {
     publications {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
-//            artifact(tasks())
         }
     }
     repositories {
@@ -129,6 +128,7 @@ fun MavenPublication.updateName() {
         "jdbc" -> "Salesforce Data Cloud JDBC Driver"
         "jdbc-core" -> "Salesforce Data Cloud JDBC Core"
         "jdbc-grpc" -> "Salesforce Data Cloud JDBC gRPC"
+        "jdbc-proto" -> "Salesforce Data Cloud JDBC Proto Files"
         else -> {
             logger.lifecycle("Unknown project, can't update name. artifactId=${this.artifactId}")
             null
@@ -146,6 +146,7 @@ fun MavenPublication.updateDescription() {
         "jdbc" -> "Salesforce Data Cloud JDBC driver"
         "jdbc-core" -> "Salesforce Data Cloud JDBC core implementation"
         "jdbc-grpc" -> "Salesforce Data Cloud Query v3 API gRPC stubs"
+        "jdbc-proto" -> "Salesforce Data Cloud Query API proto files"
         else -> {
             logger.lifecycle("Unknown project, can't update description. artifactId=${this.artifactId}")
             null

--- a/buildSrc/src/main/kotlin/version-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/version-conventions.gradle.kts
@@ -1,0 +1,19 @@
+
+val revision: String by project
+
+private val ci = object {
+    private val snapshotVersion = when (System.getenv("GITHUB_RUN_NUMBER")) {
+        null -> "$revision-LOCAL"
+        else -> "$revision-SNAPSHOT"
+    }
+
+    private val releaseVersion = System.getenv("RELEASE_VERSION")?.ifBlank {
+        logger.lifecycle("env.RELEASE_VERSION not present, assuming snapshot")
+        null
+    }
+
+    val resolvedVersion = releaseVersion ?: snapshotVersion
+}
+
+group = "com.salesforce.datacloud"
+version = ci.resolvedVersion

--- a/jdbc-core/build.gradle.kts
+++ b/jdbc-core/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":jdbc-grpc"))
+    compileOnly(project(":jdbc-grpc"))
 
     implementation(libs.slf4j.api)
 
@@ -31,6 +31,7 @@ dependencies {
 
     runtimeOnly(libs.jjwt.jackson)
 
+    testImplementation(project(":jdbc-grpc"))
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.testing)
     testImplementation(libs.bundles.mocking)

--- a/jdbc-grpc/build.gradle.kts
+++ b/jdbc-grpc/build.gradle.kts
@@ -38,11 +38,13 @@ tasks.withType<JavaCompile> {
 
 val protoJar by tasks.registering(Jar::class) {
     group = LifecycleBasePlugin.BUILD_GROUP
-    archiveClassifier.set("proto")
+    archiveBaseName.set("jdbc-proto")
     from(project.projectDir.resolve("src/main/proto"))
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 tasks.jar {
+    archiveBaseName.set("jdbc-grpc")
     val tasks = sourceSets.map { sourceSet ->
         from(sourceSet.output)
         sourceSet.getCompileTaskName("java")
@@ -50,13 +52,30 @@ tasks.jar {
 
     dependsOn(protoJar, *tasks)
 
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+val emptySourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+    archiveBaseName.set("jdbc-proto")
+}
+
+val emptyJavadocJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+    archiveBaseName.set("jdbc-proto")
 }
 
 publishing {
     publications {
         named<MavenPublication>("mavenJava") {
+            artifactId = "jdbc-grpc"
+        }
+
+        create<MavenPublication>("mavenProto") {
+            artifactId = "jdbc-proto"
             artifact(protoJar)
+            artifact(emptySourcesJar)
+            artifact(emptyJavadocJar)
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,3 +3,4 @@ rootProject.name = "jdbc-build"
 include(":jdbc-grpc")
 include(":jdbc-core")
 include(":jdbc")
+include(":verification")

--- a/verification/build.gradle.kts
+++ b/verification/build.gradle.kts
@@ -1,0 +1,101 @@
+plugins {
+  id("base-conventions")
+  id("version-conventions")
+  id("dev.adamko.dev-publish")
+}
+
+dependencies {
+  devPublication(project(":jdbc"))
+  devPublication(project(":jdbc-core"))
+  devPublication(project(":jdbc-grpc"))
+}
+
+tasks.named("check") {
+  dependsOn("updateDevRepo")
+
+  group = "verification"
+  description = "Verifies that all subprojects produce required JAR artifacts"
+
+  val expectedVersion = provider { "$version" }
+
+  val repo = devPublish.devMavenRepo.file("com/salesforce/datacloud/").get().asFile
+
+  doLast {
+    val expectedPublications = setOf("jdbc", "jdbc-grpc", "jdbc-proto", "jdbc-core")
+    val shaded = setOf("jdbc")
+
+    val resolvedVersion = expectedVersion.get()
+
+    fun hasJar(artifactId: String, version: String, classifier: String? = null): Boolean {
+      val versionDir = repo.resolve("${artifactId}/${version}")
+      
+      if (!versionDir.exists()) {
+        logger.lifecycle("Directory does not exist: ${versionDir.absolutePath}")
+        return false
+      }
+      
+      val classifierPart = classifier?.let { "-$it" } ?: ""
+      
+      // Check for exact version match (non-snapshot)
+      val exactFile = versionDir.resolve("${artifactId}-${version}${classifierPart}.jar")
+      if (exactFile.exists()) {
+        logger.lifecycle("Found exact version match: ${exactFile.name}")
+        return true
+      }
+      
+      // Check for snapshot version with timestamp (if it's a snapshot)
+      if (version.endsWith("-SNAPSHOT")) {
+        // Look for timestamp pattern like: artifactId-version-timestamp-number-classifier.jar
+        val snapshotFiles = versionDir.listFiles { file -> 
+          file.isFile && 
+          file.name.matches("${artifactId}-.*${classifierPart}\\.jar".toRegex()) && 
+          !file.name.endsWith("-SNAPSHOT${classifierPart}.jar")
+        }
+        
+        if (snapshotFiles?.isNotEmpty() == true) {
+          logger.lifecycle("Found snapshot version: ${snapshotFiles.first().name}")
+          return true
+        }
+      }
+      
+      logger.lifecycle("No matching JAR found for ${artifactId}-${version}${classifierPart}.jar")
+      return false
+    }
+
+    val failures = mutableListOf<String>()
+    val verified = mutableListOf<String>()
+
+    expectedPublications.forEach { artifactId ->
+      logger.lifecycle("Verifying artifacts for publication $artifactId:$resolvedVersion...")
+
+      if (!hasJar(artifactId, resolvedVersion)) {
+        failures.add("Publication '$artifactId' is missing main JAR")
+      }
+
+      if (!hasJar(artifactId, resolvedVersion, "sources")) {
+        failures.add("Publication '$artifactId' is missing sources JAR")
+      }
+
+      if (!hasJar(artifactId, resolvedVersion, "javadoc")) {
+        failures.add("Publication '$artifactId' is missing javadoc JAR")
+      }
+
+      if (shaded.contains(artifactId) && !hasJar(artifactId, resolvedVersion, "shaded")) {
+        failures.add("Publication '$artifactId' is missing shaded JAR")
+      }
+
+      verified.add(artifactId)
+      logger.lifecycle("  Checked publication: $artifactId version $resolvedVersion")
+    }
+
+    if (failures.isNotEmpty()) {
+      failures.forEach { logger.error(it) }
+      throw GradleException("Artifact verification failed. Some projects are missing required JAR files:\n" + failures.joinToString("\n"))
+    } else if (!verified.containsAll(expectedPublications)) {
+      val missing = expectedPublications - verified.toSet()
+      throw GradleException("Missing expected publication(s): $missing")
+    } else {
+      logger.lifecycle("All subprojects successfully generated required JAR artifacts.")
+    }
+  }
+}


### PR DESCRIPTION
Separates proto files from jdbc-grpc classifier artifact into a dedicated jdbc-proto. This improves visibility and accessibility of the proto files for consumers who need them without requiring the full grpc implementation.