### PR TITLE
fix:  prevent subsequent getQueryInfo on small query

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java
@@ -113,8 +113,18 @@ public class AdaptiveQueryStatusListener implements QueryStatusListener {
         return Optional.ofNullable(item).map(ExecuteQueryResponse::getQueryResult);
     }
 
+    private boolean allResultsInHead() {
+        return Optional.ofNullable(lastStatus.get())
+                .map(s -> s.allResultsProduced() && s.getChunkCount() < 2)
+                .orElse(false);
+    }
+
     @SneakyThrows
     private Stream<QueryResult> tail() {
+        if (allResultsInHead()) {
+            return Stream.empty();
+        }
+
         val status = client.waitForResultsProduced(queryId, timeout);
 
         if (!status.allResultsProduced()) {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingMockTests.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingMockTests.java
@@ -89,4 +89,19 @@ public class DataCloudQueryPollingMockTests extends HyperGrpcTestBase {
             verifyThat(calledMethod(HyperServiceGrpc.getGetQueryInfoMethod()), atLeast(2));
         }
     }
+
+    @SneakyThrows
+    @Test
+    void noFinalGetQueryInfoOnSmallData() {
+        try (val connection = getInterceptedClientConnection();
+             val statement = connection.createStatement()) {
+            val rs = statement.executeQuery("SELECT s FROM generate_series(1,10) s");
+
+            while (rs.next()) {
+                System.out.println("Retrieved value:" + rs.getLong(1));
+            }
+
+            verifyThat(calledMethod(HyperServiceGrpc.getGetQueryInfoMethod()), times(0));
+        }
+    }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingMockTests.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingMockTests.java
@@ -94,7 +94,7 @@ public class DataCloudQueryPollingMockTests extends HyperGrpcTestBase {
     @Test
     void noFinalGetQueryInfoOnSmallData() {
         try (val connection = getInterceptedClientConnection();
-             val statement = connection.createStatement()) {
+                val statement = connection.createStatement()) {
             val rs = statement.executeQuery("SELECT s FROM generate_series(1,10) s");
 
             while (rs.next()) {


### PR DESCRIPTION
Enhancements to query result handling:

* [`jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java`](diffhunk://#diff-c22f047bc3e8cd467e08d7343f2ca7025eab4aa351895dae3fd4d456615b0620R116-R127): Added the `allResultsInHead` method to check if all results are produced and the chunk count is less than 2, and used this method in the `tail` method to return an empty stream if all results are in the head.

New test case:

* [`jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingMockTests.java`](diffhunk://#diff-f6307e3bd1b0c180e5088a11d03bafc751addf629f6ad8059951763bd7a63348R92-R106): Added the `noFinalGetQueryInfoOnSmallData` test to verify that `getQueryInfo` is not called when dealing with small data sets.