### PR TITLE
Add simple logging for key areas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ pom.xml.bak
 .hyper
 .kotlin
 bin
+out

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -38,6 +38,23 @@ tasks.withType<Javadoc> {
     }
 }
 
+tasks.register("generateVersionProperties") {
+    val resourcesDir = layout.buildDirectory.dir("resources/main")
+    val version = project.version
+    outputs.dir(resourcesDir)
+
+    doLast {
+        val propertiesFile = resourcesDir.get().file("driver-version.properties")
+        propertiesFile.asFile.parentFile.mkdirs()
+        propertiesFile.asFile.writeText("version=$version")
+        logger.lifecycle("version written to driver-version.properties. version=$version")
+    }
+}
+
+tasks.named("compileJava") {
+    dependsOn("generateVersionProperties")
+}
+
 tasks.withType<Test>().configureEach {
 
     javaLauncher = javaToolchains.launcherFor {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudResultSet.java
@@ -21,7 +21,7 @@ import java.sql.ResultSet;
 public interface DataCloudResultSet extends ResultSet {
     String getQueryId();
 
-    String getStatus();
+    String getStatus() throws DataCloudJDBCException;
 
     boolean isReady() throws DataCloudJDBCException;
 }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
@@ -111,7 +111,7 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
     }
 
     @Override
-    public String getStatus() {
+    public String getStatus() throws DataCloudJDBCException {
         return listener.getStatus();
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java
@@ -80,7 +80,7 @@ public class AdaptiveQueryStatusListener implements QueryStatusListener {
     }
 
     @Override
-    public String getStatus() {
+    public String getStatus() throws DataCloudJDBCException {
         return client.getQueryStatus(queryId)
                 .map(DataCloudQueryStatus::getCompletionStatus)
                 .map(Enum::name)

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListener.java
@@ -83,7 +83,7 @@ public class AsyncQueryStatusListener implements QueryStatusListener {
     }
 
     @Override
-    public String getStatus() {
+    public String getStatus() throws DataCloudJDBCException {
         return client.getQueryStatus(queryId)
                 .map(DataCloudQueryStatus::getCompletionStatus)
                 .map(Enum::name)

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListener.java
@@ -29,7 +29,7 @@ public interface QueryStatusListener {
 
     boolean isReady() throws DataCloudJDBCException;
 
-    String getStatus();
+    String getStatus() throws DataCloudJDBCException;
 
     String getQueryId();
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPolling.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPolling.java
@@ -157,11 +157,18 @@ public class DataCloudQueryPolling {
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .peek(last::set)
-                    .filter(predicate::test)
+                    .filter(predicate)
                     .findFirst();
 
             if (matched.isPresent()) {
                 return matched.get();
+            }
+
+            if (Optional.ofNullable(last.get())
+                    .map(DataCloudQueryStatus::allResultsProduced)
+                    .orElse(false)) {
+                log.warn("predicate did not match but all results were produced. last={}", last.get());
+                return last.get();
             }
 
             log.info(

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/RowBased.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/RowBased.java
@@ -16,12 +16,14 @@
 package com.salesforce.datacloud.jdbc.core.partial;
 
 import com.salesforce.datacloud.jdbc.core.HyperGrpcClientExecutor;
+import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.SneakyThrows;
 import lombok.val;
 import salesforce.cdp.hyperdb.v1.QueryResult;
 
@@ -39,7 +41,7 @@ class RowBasedContext {
     @Getter
     private final AtomicLong seen = new AtomicLong(0);
 
-    public Iterator<QueryResult> getQueryResult(boolean omitSchema) {
+    public Iterator<QueryResult> getQueryResult(boolean omitSchema) throws DataCloudJDBCException {
         val currentOffset = offset + seen.get();
         val currentLimit = limit - seen.get();
         return client.getQueryResult(queryId, currentOffset, currentLimit, omitSchema);
@@ -62,7 +64,8 @@ public interface RowBased extends Iterator<QueryResult> {
             @NonNull String queryId,
             long offset,
             long limit,
-            @NonNull Mode mode) {
+            @NonNull Mode mode)
+            throws DataCloudJDBCException {
         val context = RowBasedContext.builder()
                 .client(client)
                 .queryId(queryId)
@@ -102,6 +105,7 @@ class RowBasedFullRange implements RowBased {
 
     private Iterator<QueryResult> iterator;
 
+    @SneakyThrows
     @Override
     public boolean hasNext() {
         if (iterator == null) {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
@@ -47,6 +47,7 @@ class AsyncQueryStatusListenerTest extends HyperGrpcTestBase {
     private final String query = "select * from stuff";
     private final QueryParam.TransferMode mode = QueryParam.TransferMode.ASYNC;
 
+    @SneakyThrows
     @ParameterizedTest
     @CsvSource({"0, RUNNING", "1, RESULTS_PRODUCED", "2, FINISHED"})
     void itCanGetStatus(int value, String expected) {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerAssert.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerAssert.java
@@ -140,6 +140,7 @@ public class QueryStatusListenerAssert extends AbstractObjectAssert<QueryStatusL
      * @return this assertion object.
      * @throws AssertionError - if the actual QueryStatusListener's status is not equal to the given one.
      */
+    @SneakyThrows
     public QueryStatusListenerAssert hasStatus(String status) {
         // check that actual QueryStatusListener we want to make assertions on is not null.
         isNotNull();

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/ChunkBasedTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/ChunkBasedTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Slf4j
 @ExtendWith(HyperTestBase.class)
 class ChunkBasedTest {
+    @SneakyThrows
     private List<Integer> sut(String queryId, long chunkId, long limit) {
         try (val connection = getHyperQueryConnection()) {
             val rs = limit == 1

--- a/jdbc-core/src/test/resources/simplelogger.properties
+++ b/jdbc-core/src/test/resources/simplelogger.properties
@@ -1,2 +1,2 @@
 org.slf4j.simpleLogger.logFile=System.out
-org.slf4j.simpleLogger.defaultLogLevel=warn
+org.slf4j.simpleLogger.defaultLogLevel=info

--- a/jdbc-util/build.gradle.kts
+++ b/jdbc-util/build.gradle.kts
@@ -14,19 +14,6 @@ dependencies {
     testImplementation(libs.bundles.mocking)
 }
 
-tasks.register("generateVersionProperties") {
-    val resourcesDir = layout.buildDirectory.dir("resources/main")
-    val version = project.version
-    outputs.dir(resourcesDir)
 
-    doLast {
-        val propertiesFile = resourcesDir.get().file("driver-version.properties")
-        propertiesFile.asFile.parentFile.mkdirs()
-        propertiesFile.asFile.writeText("version=$version")
-        logger.lifecycle("version written to driver-version.properties. version=$version")
-    }
-}
 
-tasks.named("compileJava") {
-    dependsOn("generateVersionProperties")
-}
+

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/logging/ElapsedLogger.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/logging/ElapsedLogger.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.logging;
+
+import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
+import com.salesforce.datacloud.jdbc.util.ThrowingJdbcSupplier;
+import java.sql.SQLException;
+import java.time.Duration;
+import lombok.experimental.UtilityClass;
+import lombok.val;
+import org.slf4j.Logger;
+
+@UtilityClass
+public class ElapsedLogger {
+    public static <T> T logTimedValue(ThrowingJdbcSupplier<T> supplier, String name, Logger logger)
+            throws DataCloudJDBCException {
+        val start = System.currentTimeMillis();
+        try {
+            logger.info("Starting name={}", name);
+            val result = supplier.get();
+            val elapsed = System.currentTimeMillis() - start;
+            logger.info("Success name={}, millis={}, duration={}", name, elapsed, Duration.ofMillis(elapsed));
+            return result;
+        } catch (DataCloudJDBCException e) {
+            val elapsed = System.currentTimeMillis() - start;
+            logger.error("Failed name={}, millis={}, duration={}", name, elapsed, Duration.ofMillis(elapsed), e);
+            throw e;
+        } catch (SQLException e) {
+            val elapsed = System.currentTimeMillis() - start;
+            logger.error("Failed name={}, millis={}, duration={}", name, elapsed, Duration.ofMillis(elapsed), e);
+            throw new DataCloudJDBCException(e);
+        }
+    }
+}

--- a/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
+++ b/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
@@ -136,7 +136,7 @@ public class DataCloudJDBCDriver implements Driver {
         val dataspaceClient = new DataspaceClient(properties, tokenProcessor);
 
         return DataCloudConnection.fromOauth(
-                builder, properties, authInterceptor, tokenProcessor::getLakehouse, dataspaceClient);
+                builder, properties, authInterceptor, tokenProcessor::getLakehouse, dataspaceClient, connectionString);
     }
 
     static void addClientUsernameIfRequired(Properties properties) {


### PR DESCRIPTION
We want to see logging for time to establish connection as well as most gRPC calls. This is an MVP change to get that done without a much larger refactor that I found myself making by using a decorator pattern.