### PR TITLE
feature: Add Float4Vector support - Add FloatVectorAccessor, tests, and wire up in factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ pom.xml.bak
 bin
 out
 .worktree
+gradle
+!gradle/libs.versions.toml
+!gradle/wrapper/gradle-wrapper.jar
+!gradle/wrapper/gradle-wrapper.properties

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessorFactory.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessorFactory.java
@@ -21,6 +21,7 @@ import com.salesforce.datacloud.jdbc.core.accessor.impl.BooleanVectorAccessor;
 import com.salesforce.datacloud.jdbc.core.accessor.impl.DateVectorAccessor;
 import com.salesforce.datacloud.jdbc.core.accessor.impl.DecimalVectorAccessor;
 import com.salesforce.datacloud.jdbc.core.accessor.impl.DoubleVectorAccessor;
+import com.salesforce.datacloud.jdbc.core.accessor.impl.FloatVectorAccessor;
 import com.salesforce.datacloud.jdbc.core.accessor.impl.LargeListVectorAccessor;
 import com.salesforce.datacloud.jdbc.core.accessor.impl.ListVectorAccessor;
 import com.salesforce.datacloud.jdbc.core.accessor.impl.TimeStampVectorAccessor;
@@ -34,6 +35,7 @@ import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
@@ -79,6 +81,8 @@ public class QueryJDBCAccessorFactory {
             return new DecimalVectorAccessor((DecimalVector) vector, getCurrentRow, wasNullConsumer);
         } else if (arrowType.equals(Types.MinorType.BIT)) {
             return new BooleanVectorAccessor((BitVector) vector, getCurrentRow, wasNullConsumer);
+        } else if (arrowType.equals(Types.MinorType.FLOAT4)) {
+            return new FloatVectorAccessor((Float4Vector) vector, getCurrentRow, wasNullConsumer);
         } else if (arrowType.equals(Types.MinorType.FLOAT8)) {
             return new DoubleVectorAccessor((Float8Vector) vector, getCurrentRow, wasNullConsumer);
         } else if (arrowType.equals(Types.MinorType.TINYINT)) {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.core.accessor.impl;
+
+import com.salesforce.datacloud.jdbc.core.accessor.QueryJDBCAccessor;
+import com.salesforce.datacloud.jdbc.core.accessor.QueryJDBCAccessorFactory;
+import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.SQLException;
+import java.util.function.IntSupplier;
+import lombok.val;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.holders.NullableFloat4Holder;
+
+public class FloatVectorAccessor extends QueryJDBCAccessor {
+
+    private final Float4Vector vector;
+    private final NullableFloat4Holder holder;
+
+    private static final String INVALID_VALUE_ERROR_RESPONSE = "BigDecimal doesn't support Infinite/NaN";
+
+    public FloatVectorAccessor(
+            Float4Vector vector,
+            IntSupplier currentRowSupplier,
+            QueryJDBCAccessorFactory.WasNullConsumer setCursorWasNull) {
+        super(currentRowSupplier, setCursorWasNull);
+        this.holder = new NullableFloat4Holder();
+        this.vector = vector;
+    }
+
+    @Override
+    public Class<?> getObjectClass() {
+        return Float.class;
+    }
+
+    @Override
+    public float getFloat() {
+        vector.get(getCurrentRow(), holder);
+
+        this.wasNull = holder.isSet == 0;
+        this.wasNullConsumer.setWasNull(this.wasNull);
+        if (this.wasNull) {
+            return 0;
+        }
+
+        return holder.value;
+    }
+
+    @Override
+    public Object getObject() {
+        final float value = this.getFloat();
+
+        return this.wasNull ? null : value;
+    }
+
+    @Override
+    public String getString() {
+        final float value = this.getFloat();
+        return this.wasNull ? null : Float.toString(value);
+    }
+
+    @Override
+    public boolean getBoolean() {
+        return this.getFloat() != 0.0f;
+    }
+
+    @Override
+    public byte getByte() {
+        return (byte) this.getFloat();
+    }
+
+    @Override
+    public short getShort() {
+        return (short) this.getFloat();
+    }
+
+    @Override
+    public int getInt() {
+        return (int) this.getFloat();
+    }
+
+    @Override
+    public long getLong() {
+        return (long) this.getFloat();
+    }
+
+    @Override
+    public double getDouble() {
+        return this.getFloat();
+    }
+
+    @Override
+    public BigDecimal getBigDecimal() throws SQLException {
+        final float value = this.getFloat();
+        if (Float.isInfinite(value) || Float.isNaN(value)) {
+            val rootCauseException = new UnsupportedOperationException(INVALID_VALUE_ERROR_RESPONSE);
+            throw new DataCloudJDBCException(INVALID_VALUE_ERROR_RESPONSE, "2200G", rootCauseException);
+        }
+        return this.wasNull ? null : BigDecimal.valueOf(value);
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int scale) throws SQLException {
+        final float value = this.getFloat();
+        if (Float.isInfinite(value) || Float.isNaN(value)) {
+            val rootCauseException = new UnsupportedOperationException(INVALID_VALUE_ERROR_RESPONSE);
+            throw new DataCloudJDBCException(INVALID_VALUE_ERROR_RESPONSE, "2200G", rootCauseException);
+        }
+        return this.wasNull ? null : BigDecimal.valueOf(value).setScale(scale, RoundingMode.HALF_UP);
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/Float4VectorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/Float4VectorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import static com.salesforce.datacloud.jdbc.hyper.HyperTestBase.assertWithStatement;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.salesforce.datacloud.jdbc.hyper.HyperTestBase;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(HyperTestBase.class)
+public class Float4VectorTest {
+
+    @Test
+    public void testFloat4VectorQuery() {
+        // Expected values from generate_series(1, 10, 0.5)
+        val expectedValues =
+                IntStream.rangeClosed(0, 18).mapToObj(i -> 1.0f + (i * 0.5f)).collect(Collectors.toList());
+
+        assertWithStatement(statement -> {
+            ResultSet rs = statement.executeQuery("select i::real from generate_series(1, 10, 0.5) g(i)");
+
+            List<Float> actualValues = new ArrayList<>();
+            while (rs.next()) {
+                actualValues.add(rs.getFloat(1));
+            }
+
+            assertThat(actualValues).containsExactlyElementsOf(expectedValues);
+        });
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.core.accessor.impl;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.salesforce.datacloud.jdbc.core.accessor.SoftAssertions;
+import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
+import com.salesforce.datacloud.jdbc.util.RootAllocatorTestExtension;
+import com.salesforce.datacloud.jdbc.util.TestWasNullConsumer;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.val;
+import org.assertj.core.api.ThrowingConsumer;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class FloatVectorAccessorTest {
+    @InjectSoftAssertions
+    private SoftAssertions collector;
+
+    @RegisterExtension
+    public static RootAllocatorTestExtension extension = new RootAllocatorTestExtension();
+
+    private static final int total = 10;
+    private static final Random random = new Random(10);
+    private static final List<Float> values = IntStream.range(0, total - 2)
+            .mapToDouble(x -> random.nextFloat())
+            .filter(Double::isFinite)
+            .mapToObj(x -> (float) x)
+            .collect(Collectors.toList());
+
+    @BeforeAll
+    static void setup() {
+        values.add(null);
+        values.add(null);
+        Collections.shuffle(values);
+    }
+
+    private TestWasNullConsumer iterate(List<Float> values, BuildThrowingConsumer builder) {
+        val consumer = new TestWasNullConsumer(collector);
+
+        try (val vector = extension.createFloat4Vector(values)) {
+            val i = new AtomicInteger(0);
+            val sut = new FloatVectorAccessor(vector, i::get, consumer);
+
+            for (; i.get() < vector.getValueCount(); i.incrementAndGet()) {
+                val expected = values.get(i.get());
+                val s = builder.buildSatisfies(expected);
+                collector.assertThat(sut).satisfies(b -> s.accept((FloatVectorAccessor) b));
+            }
+        }
+
+        return consumer;
+    }
+
+    private TestWasNullConsumer iterate(BuildThrowingConsumer builder) {
+        val consumer = iterate(values, builder);
+        consumer.assertThat().hasNullSeen(2).hasNotNullSeen(values.size() - 2);
+        return consumer;
+    }
+
+    @FunctionalInterface
+    private interface BuildThrowingConsumer {
+        ThrowingConsumer<FloatVectorAccessor> buildSatisfies(Float expected);
+    }
+
+    @Test
+    void testShouldGetFloatMethodFromFloat4Vector() {
+        iterate(expected -> sut -> collector.assertThat(sut).hasFloat(expected == null ? 0.0f : expected));
+    }
+
+    @Test
+    void testShouldGetObjectMethodFromFloat4Vector() {
+        iterate(expected -> sut -> collector.assertThat(sut).hasObject(expected));
+    }
+
+    @Test
+    void testShouldGetStringMethodFromFloat4Vector() {
+        iterate(expected ->
+                sut -> collector.assertThat(sut).hasString(expected == null ? null : Float.toString(expected)));
+    }
+
+    @Test
+    void testShouldGetBooleanMethodFromFloat4Vector() {
+        iterate(expected -> sut -> collector.assertThat(sut).hasBoolean(expected != null && (expected != 0.0f)));
+    }
+
+    @Test
+    void testShouldGetByteMethodFromFloat4Vector() {
+        iterate(expected -> sut -> collector.assertThat(sut).hasByte((byte) (expected == null ? 0.0f : expected)));
+    }
+
+    @Test
+    void testShouldGetShortMethodFromFloat4Vector() {
+        iterate(expected -> sut -> collector.assertThat(sut).hasShort((short) (expected == null ? 0.0f : expected)));
+    }
+
+    @Test
+    void testShouldGetIntMethodFromFloat4Vector() {
+        iterate(expected -> sut -> collector.assertThat(sut).hasInt((int) (expected == null ? 0.0f : expected)));
+    }
+
+    @Test
+    void testShouldGetLongMethodFromFloat4Vector() {
+        iterate(expected -> sut -> collector.assertThat(sut).hasLong((long) (expected == null ? 0.0f : expected)));
+    }
+
+    @Test
+    void testShouldGetDoubleMethodFromFloat4Vector() {
+        iterate(expected -> sut -> collector.assertThat(sut).hasDouble(expected == null ? 0.0f : expected));
+    }
+
+    @Test
+    void testGetBigDecimalIllegalFloatsMethodFromFloat4Vector() {
+        val consumer = iterate(
+                ImmutableList.of(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN),
+                expected -> sut -> assertThrows(DataCloudJDBCException.class, sut::getBigDecimal));
+        consumer.assertThat().hasNullSeen(0).hasNotNullSeen(3);
+    }
+
+    @Test
+    void testShouldGetBigDecimalWithScaleMethodFromFloat4Vector() {
+        val scale = 9;
+        val big = Float.MAX_VALUE;
+        val expected = BigDecimal.valueOf(big).setScale(scale, RoundingMode.HALF_UP);
+        iterate(
+                ImmutableList.of(Float.MAX_VALUE),
+                e -> sut -> collector.assertThat(sut.getBigDecimal(scale)).isEqualTo(expected));
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/RootAllocatorTestExtension.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/RootAllocatorTestExtension.java
@@ -35,6 +35,7 @@ import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
@@ -94,6 +95,21 @@ public class RootAllocatorTestExtension implements AfterAllCallback, AutoCloseab
                 vector.setNull(i);
             } else {
                 vector.setSafe(i, d);
+            }
+        }
+        vector.setValueCount(values.size());
+        return vector;
+    }
+
+    public Float4Vector createFloat4Vector(List<Float> values) {
+        val vector = new Float4Vector("test-float-vector", getRootAllocator());
+        vector.allocateNew(values.size());
+        for (int i = 0; i < values.size(); i++) {
+            Float f = values.get(i);
+            if (f == null) {
+                vector.setNull(i);
+            } else {
+                vector.setSafe(i, f);
             }
         }
         vector.setValueCount(values.size());


### PR DESCRIPTION
This change adds support for the Float4Vector data type in the JDBC driver, allowing proper handling of 32-bit floating point numbers.