### PR TITLE
feat: add http logging and grpc tracing from oauth driver

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ org.gradle.caching=true
 
 hyperApiVersion=0.0.21408.rf5a406c0
 
-revision=0.27.0
+revision=0.26.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ org.gradle.caching=true
 
 hyperApiVersion=0.0.21408.rf5a406c0
 
-revision=0.25.7
+revision=0.27.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,8 +28,9 @@ plugin-build-buf = "0.10.2"
 [libraries]
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "com-fasterxml-jackson-core-jackson-databind" }
 guava = { module = "com.google.guava:guava", version.ref = "com-google-guava-guava" }
+okhttp3-client = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
+okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3" }
 okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
-okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 grpc-netty = { module = "io.grpc:grpc-netty", version.ref = "grpc" }
 grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }

--- a/jdbc-http/build.gradle.kts
+++ b/jdbc-http/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
 
 dependencies {
     implementation(project(":jdbc-util"))
-    implementation(libs.okhttp3)
+    implementation(libs.okhttp3.client)
+    implementation(libs.okhttp3.logging.interceptor)
     implementation(libs.slf4j.api)
 
     implementation(libs.guava)

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/HttpClientLogger.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/HttpClientLogger.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.http;
+
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.logging.HttpLoggingInterceptor;
+import org.jetbrains.annotations.NotNull;
+
+@Slf4j
+public class HttpClientLogger implements HttpLoggingInterceptor.Logger {
+    @Override
+    public void log(@NotNull String s) {
+        log.info(s);
+    }
+}

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/PropertiesExtensions.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/PropertiesExtensions.java
@@ -19,8 +19,10 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
+@Slf4j
 @UtilityClass
 public class PropertiesExtensions {
     public static Optional<String> optional(Properties properties, String key) {
@@ -77,6 +79,26 @@ public class PropertiesExtensions {
 
     public static Boolean toBooleanOrDefault(String s) {
         return Boolean.valueOf(s);
+    }
+
+    public static <T extends Enum<T>> T getEnumOrDefault(Properties properties, String key, T defaultValue) {
+        Class<T> enumClass = defaultValue.getDeclaringClass();
+        return optional(properties, key)
+                .map(str -> toEnumOrDefault(str, enumClass))
+                .orElse(defaultValue);
+    }
+
+    public static <T extends Enum<T>> T toEnumOrDefault(String s, Class<T> enumClass) {
+        if (s == null) {
+            return null;
+        }
+
+        try {
+            return Enum.valueOf(enumClass, s);
+        } catch (Exception ex) {
+            log.warn("Failed to parse enum value: {}", s, ex);
+            return null;
+        }
     }
 
     @UtilityClass

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/PropertiesExtensionsTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/PropertiesExtensionsTest.java
@@ -32,6 +32,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 class PropertiesExtensionsTest {
     private final String key = UUID.randomUUID().toString();
 
+    enum TestEnum {
+        FIRST,
+        SECOND,
+        THIRD
+    }
+
     @Test
     void optionalValidKeyAndValue() {
         val expected = UUID.randomUUID().toString();
@@ -117,5 +123,34 @@ class PropertiesExtensionsTest {
         properties.setProperty("myKeyEmpty", "");
         Boolean resultEmpty = PropertiesExtensions.getBooleanOrDefault(properties, "myKeyEmpty", false);
         assertThat(resultEmpty).isEqualTo(false);
+    }
+
+    @Test
+    void getEnumOrDefaultReturnsEnumValueWhenValid() {
+        Properties properties = new Properties();
+        properties.setProperty("enumKey", "SECOND");
+
+        TestEnum result = PropertiesExtensions.getEnumOrDefault(properties, "enumKey", TestEnum.FIRST);
+
+        assertThat(result).isEqualTo(TestEnum.SECOND);
+    }
+
+    @Test
+    void getEnumOrDefaultReturnsDefaultWhenInvalid() {
+        Properties properties = new Properties();
+        properties.setProperty("enumKey", "INVALID_VALUE");
+
+        TestEnum result = PropertiesExtensions.getEnumOrDefault(properties, "enumKey", TestEnum.FIRST);
+
+        assertThat(result).isEqualTo(TestEnum.FIRST);
+    }
+
+    @Test
+    void getEnumOrDefaultReturnsDefaultWhenKeyMissing() {
+        Properties properties = new Properties();
+
+        TestEnum result = PropertiesExtensions.getEnumOrDefault(properties, "missingKey", TestEnum.THIRD);
+
+        assertThat(result).isEqualTo(TestEnum.THIRD);
     }
 }

--- a/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
+++ b/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
@@ -26,6 +26,7 @@ import com.salesforce.datacloud.jdbc.core.DataCloudConnection;
 import com.salesforce.datacloud.jdbc.core.DataCloudConnectionString;
 import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
 import com.salesforce.datacloud.jdbc.interceptor.TokenProcessorSupplier;
+import com.salesforce.datacloud.jdbc.interceptor.TracingHeadersInterceptor;
 import com.salesforce.datacloud.jdbc.soql.DataspaceClient;
 import com.salesforce.datacloud.jdbc.util.DirectDataCloudConnection;
 import io.grpc.ManagedChannelBuilder;
@@ -131,7 +132,9 @@ public class DataCloudJDBCDriver implements Driver {
         val authInterceptor = TokenProcessorSupplier.of(tokenProcessor);
 
         val host = tokenProcessor.getDataCloudToken().getTenantUrl();
-        val builder = ManagedChannelBuilder.forAddress(host, DataCloudConnection.DEFAULT_PORT);
+        final ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(
+                        host, DataCloudConnection.DEFAULT_PORT)
+                .intercept(TracingHeadersInterceptor.of());
 
         val dataspaceClient = new DataspaceClient(properties, tokenProcessor);
 


### PR DESCRIPTION
This pull request introduces several updates, primarily focusing on enhancing logging capabilities.

* Added HTTP logging support in `jdbc-http` by introducing a new `HttpClientLogger` class and integrating `HttpLoggingInterceptor` into the `OkHttpClient` builder. Logging levels can now be configured via a new property, `okhttp.logging.level`
* Added utility methods `getEnumOrDefault` and `toEnumOrDefault` to `PropertiesExtensions` for safer and more flexible enum handling
* Updated the `revision` property in `gradle.properties` to `0.27.0-SNAPSHOT`
* Integrated a new `TracingHeadersInterceptor` into the gRPC `ManagedChannelBuilder` in the `jdbc` module to enhance tracing capabilities