### PR TITLE
fix: add missing protobuf-java library and add flattenJars task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,3 +19,51 @@ moduleGraphConfig {
     heading.set("## Module Graph")
     rootModulesRegex.set(":jdbc")
 }
+
+tasks.register("flattenJars") {
+    description = "Collects all JARs required for the JDBC driver into a single directory"
+    group = "build"
+    
+    dependsOn(
+        ":jdbc:jar",
+        ":jdbc-core:jar", 
+        ":jdbc-grpc:jar",
+        ":jdbc-http:jar",
+        ":jdbc-util:jar"
+    )
+    
+    doLast {
+        val outputDir = layout.buildDirectory.dir("libs/all-jars").get().asFile
+        outputDir.mkdirs()
+        
+        val jdbcProjects = listOf(
+            project(":jdbc"),
+            project(":jdbc-core"),
+            project(":jdbc-grpc"),
+            project(":jdbc-http"),
+            project(":jdbc-util")
+        )
+        
+        jdbcProjects.forEach { proj ->
+            proj.tasks.findByName("jar")?.outputs?.files?.forEach { file ->
+                if (file.isFile && file.extension == "jar") {
+                    file.copyTo(outputDir.resolve(file.name), overwrite = true)
+                    logger.lifecycle("Copied project JAR: ${file.name}")
+                }
+            }
+        }
+        
+        val processedJars = mutableSetOf<String>()
+        jdbcProjects.forEach { proj ->
+            proj.configurations.findByName("runtimeClasspath")?.resolvedConfiguration?.resolvedArtifacts?.forEach { artifact ->
+                val file = artifact.file
+                if (file.extension == "jar" && processedJars.add(file.name)) {
+                    file.copyTo(outputDir.resolve(file.name), overwrite = true)
+                    logger.lifecycle("Copied dependency: ${file.name}")
+                }
+            }
+        }
+        
+        logger.lifecycle("All JARs have been collected in ${outputDir.absolutePath}")
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ org.gradle.caching=true
 
 hyperApiVersion=0.0.21408.rf5a406c0
 
-revision=0.26.1
+revision=0.26.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,8 @@ grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
 grpc-protoc = { group = "io.grpc", name = "protoc-gen-grpc-java", version.ref = "grpc" }
 grpc-inprocess = { module = "io.grpc:grpc-inprocess", version.ref = "grpc" }
 
+protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
+
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
 jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
 jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
@@ -63,7 +65,7 @@ protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protob
 
 [bundles]
 arrow = ["apache-arrow-vector", "apache-arrow-memory-netty"]
-grpc-impl = ["grpc-netty", "grpc-protobuf", "grpc-stub", "javax-annotation-api"]
+grpc-impl = ["protobuf-java", "grpc-netty", "grpc-protobuf", "grpc-stub", "javax-annotation-api"]
 grpc-testing = ["grpcmock", "grpc-inprocess"]
 testing = ["junit-jupiter-base", "junit-jupiter-api", "junit-jupiter-engine", "junit-jupiter-params", "junit-platform-launcher", "assertj", "slf4j-simple"]
 mocking = ["mockito-inline", "mockito-junit-jupiter", "okhttp3-mockwebserver"]

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/TracingHeadersInterceptor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/TracingHeadersInterceptor.java
@@ -17,7 +17,7 @@ package com.salesforce.datacloud.jdbc.interceptor;
 
 import static com.salesforce.datacloud.jdbc.interceptor.MetadataUtilities.keyOf;
 
-import com.salesforce.datacloud.jdbc.internal.Tracer;
+import com.salesforce.datacloud.jdbc.tracing.Tracer;
 import io.grpc.Metadata;
 import java.util.function.Supplier;
 import lombok.AccessLevel;

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/EmittedHeaderTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/EmittedHeaderTest.java
@@ -23,7 +23,7 @@ import com.google.protobuf.ByteString;
 import com.salesforce.datacloud.jdbc.config.DriverVersion;
 import com.salesforce.datacloud.jdbc.core.DataCloudConnection;
 import com.salesforce.datacloud.jdbc.core.DataCloudStatement;
-import com.salesforce.datacloud.jdbc.internal.Tracer;
+import com.salesforce.datacloud.jdbc.tracing.Tracer;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProcessor.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProcessor.java
@@ -132,7 +132,10 @@ public class DataCloudTokenProcessor implements TokenProcessor {
     public String getLakehouse() throws SQLException {
         val tenantId = getDataCloudToken().getTenantId();
         val dataspace = getSettings().getDataspace();
-        return "lakehouse:" + tenantId + ";" + Optional.ofNullable(dataspace).orElse("");
+        val response =
+                "lakehouse:" + tenantId + ";" + Optional.ofNullable(dataspace).orElse("");
+        log.info("Lakehouse: {}", response);
+        return response;
     }
 
     private DataCloudToken retrieveAndCacheDataCloudToken() throws SQLException {

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/EncodingUtils.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/EncodingUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.salesforce.datacloud.jdbc.internal;
+package com.salesforce.datacloud.jdbc.tracing;
 
 import javax.annotation.concurrent.Immutable;
 import lombok.experimental.UtilityClass;

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/TemporaryBuffers.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/TemporaryBuffers.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.salesforce.datacloud.jdbc.internal;
+package com.salesforce.datacloud.jdbc.tracing;
 
 import lombok.experimental.UtilityClass;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/Tracer.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/Tracer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.salesforce.datacloud.jdbc.internal;
+package com.salesforce.datacloud.jdbc.tracing;
 
 public class Tracer {
     private static final int TRACE_ID_BYTES_LENGTH = 16;

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/EncodingUtilsTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/EncodingUtilsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.salesforce.datacloud.jdbc.internal;
+package com.salesforce.datacloud.jdbc.tracing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/TemporaryBuffersTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/TemporaryBuffersTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.salesforce.datacloud.jdbc.internal;
+package com.salesforce.datacloud.jdbc.tracing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/TracerTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/TracerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.salesforce.datacloud.jdbc.internal;
+package com.salesforce.datacloud.jdbc.tracing;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This pull request includes changes to update dependencies, improve logging, and reorganize the tracing utilities. 

* Added `flattenJars` task to easily test with dbeaver without needing to wait for publication to maven central
* Updated the `revision` property in `gradle.properties` from `0.26.1` to `0.26.2`.
* Added a new dependency for `protobuf-java` in `gradle/libs.versions.toml` and included it in the `grpc-impl` bundle.
* Added logging for the `lakehouse` response in the `getLakehouse` method of `DataCloudTokenProcessor`.
* Introduced `logTimedValue` for measuring execution time in the `DataspaceClient` class and added trace and span IDs to HTTP headers for better tracing.
* Moved tracing-related classes (`EncodingUtils`, `TemporaryBuffers`, `Tracer`, and their tests) from the `jdbc-core` module to a new `jdbc-util` module under the `com.salesforce.datacloud.jdbc.tracing` package.