### PR TITLE
fix: using channel builder in DataCloudConnection should always cleanup

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
@@ -116,26 +116,25 @@ public class DataCloudConnection implements Connection, AutoCloseable {
 
     /**
      * This is a convenience overload for {@link DataCloudConnection#of(DataCloudJdbcManagedChannel, Properties, boolean)}
+     * We pass true for closeChannelWithConnection to ensure the channel that is built internally is cleaned up.
+     *
      * @param builder The builder to be passed to {@link DataCloudJdbcManagedChannel#of(ManagedChannelBuilder, Properties)}
      * @param properties The properties to be passed to {@link DataCloudJdbcManagedChannel#of(ManagedChannelBuilder, Properties)}
-     * @param closeChannelWithConnection Whether to close the channel when the connection is closed, if false you are responsible for cleaning up your managed channel.
      * @return A DataCloudConnection with the given channel and properties
      */
-    public static DataCloudConnection of(
-            @NonNull ManagedChannelBuilder<?> builder,
-            @NonNull Properties properties,
-            boolean closeChannelWithConnection)
+    public static DataCloudConnection of(@NonNull ManagedChannelBuilder<?> builder, @NonNull Properties properties)
             throws DataCloudJDBCException {
-        return of(DataCloudJdbcManagedChannel.of(builder, properties), properties, closeChannelWithConnection);
+        return of(DataCloudJdbcManagedChannel.of(builder, properties), properties, true);
     }
 
     /**
      * This overload is intended to be used from the {@code DataCloudJDBCDriver} and assumes a Data Cloud token is wired to the suppliers
+     * We pass true for closeChannelWithConnection to ensure the channel that is built internally is cleaned up.
+     *
      * @param properties The properties to be passed to {@link DataCloudJdbcManagedChannel#of(ManagedChannelBuilder, Properties)}
      * @param authInterceptor a {@link ClientInterceptor} wired to provide an auth token for network requests
      * @param lakehouseSupplier a supplier that acquires the lakehouse from a Data Cloud token
      * @param dataspacesSupplier a supplier that acquires available dataspaces using a Data Cloud token
-     * @param closeChannelWithConnection Whether to close the channel when the connection is closed, if false you are responsible for cleaning up your managed channel.
      * @return A DataCloudConnection with the given channel and properties
      */
     public static DataCloudConnection of(
@@ -144,8 +143,7 @@ public class DataCloudConnection implements Connection, AutoCloseable {
             @NonNull ClientInterceptor authInterceptor,
             @NonNull ThrowingJdbcSupplier<String> lakehouseSupplier,
             @NonNull ThrowingJdbcSupplier<List<String>> dataspacesSupplier,
-            @NonNull DataCloudConnectionString connectionString,
-            boolean closeChannelWithConnection)
+            @NonNull DataCloudConnectionString connectionString)
             throws DataCloudJDBCException {
         return logTimedValue(
                 () -> DataCloudConnection.builder()
@@ -154,10 +152,8 @@ public class DataCloudConnection implements Connection, AutoCloseable {
                         .lakehouseSupplier(lakehouseSupplier)
                         .dataspacesSupplier(dataspacesSupplier)
                         .connectionString(connectionString)
-                        .shouldCloseChannelWithConnection(closeChannelWithConnection)
                         .build(),
-                "DataCloudConnection::of with oauth enabled suppliers. closeChannelWithConnection="
-                        + closeChannelWithConnection,
+                "DataCloudConnection::of with oauth enabled suppliers",
                 log);
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/DirectDataCloudConnection.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/DirectDataCloudConnection.java
@@ -50,6 +50,6 @@ public class DirectDataCloudConnection {
         ManagedChannelBuilder<?> builder =
                 ManagedChannelBuilder.forAddress(uri.getHost(), uri.getPort()).usePlaintext();
 
-        return DataCloudConnection.of(builder, properties, true);
+        return DataCloudConnection.of(builder, properties);
     }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcTestBase.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcTestBase.java
@@ -126,7 +126,7 @@ public class HyperGrpcTestBase {
                 HyperServiceGrpc.getGetQueryResultMethod(),
                 HyperServiceGrpc.HyperServiceBlockingStub::getQueryResult);
 
-        val conn = DataCloudConnection.of(mocked, new Properties(), true);
+        val conn = DataCloudConnection.of(mocked, new Properties());
         connections.add(conn);
         return conn;
     }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/ChunkBasedPaginationTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/ChunkBasedPaginationTest.java
@@ -54,7 +54,7 @@ public class ChunkBasedPaginationTest {
 
         final String queryId;
 
-        try (final DataCloudConnection conn = DataCloudConnection.of(channel, properties, true);
+        try (final DataCloudConnection conn = DataCloudConnection.of(channel, properties);
                 final DataCloudStatement stmt = conn.createStatement().unwrap(DataCloudStatement.class)) {
             queryId = stmt.executeAsyncQuery(sql).getQueryId();
         }
@@ -62,7 +62,7 @@ public class ChunkBasedPaginationTest {
         int prev = 1;
         DataCloudQueryStatus status = null;
         while (true) {
-            try (final DataCloudConnection conn = DataCloudConnection.of(channel, properties, true)) {
+            try (final DataCloudConnection conn = DataCloudConnection.of(channel, properties)) {
                 if (status == null || !status.allResultsProduced()) {
                     status = conn.waitForChunksAvailable(
                             queryId, offset.get(), 1, timeout, false); // false because we're waiting for the next chunk

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/RowBasedPaginationTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/RowBasedPaginationTest.java
@@ -63,7 +63,7 @@ public class RowBasedPaginationTest {
         final String queryId;
         long currentOffset = 0;
 
-        try (final DataCloudConnection conn = DataCloudConnection.of(channel, properties, true);
+        try (final DataCloudConnection conn = DataCloudConnection.of(channel, properties);
                 final DataCloudStatement stmt = conn.createStatement().unwrap(DataCloudStatement.class)) {
             // Set the initial page size
             stmt.setResultSetConstraints(pageSize);
@@ -85,7 +85,7 @@ public class RowBasedPaginationTest {
         assertThat(allResults).containsExactly(1L, 2L);
 
         // Step 2: Retrieve remaining pages
-        try (final DataCloudConnection conn = DataCloudConnection.of(channel, properties, true)) {
+        try (final DataCloudConnection conn = DataCloudConnection.of(channel, properties)) {
             DataCloudQueryStatus status = conn.waitForRowsAvailable(queryId, currentOffset, pageSize, timeout, true);
 
             while (true) {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/SubmitQueryAndConsumeResultsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/SubmitQueryAndConsumeResultsTest.java
@@ -50,7 +50,7 @@ public class SubmitQueryAndConsumeResultsTest {
                 .usePlaintext();
 
         // Use the JDBC Driver interface
-        try (DataCloudConnection conn = DataCloudConnection.of(channel, properties, true)) {
+        try (DataCloudConnection conn = DataCloudConnection.of(channel, properties)) {
             try (Statement stmt = conn.createStatement()) {
                 ResultSet rs = stmt.executeQuery("SELECT s FROM generate_series(1,10) s");
                 while (rs.next()) {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/HyperTestBase.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/HyperTestBase.java
@@ -81,7 +81,7 @@ public class HyperTestBase implements BeforeAllCallback, ExtensionContext.Store.
                 .usePlaintext()
                 .intercept(interceptors);
 
-        return DataCloudConnection.of(channel, new Properties(), true);
+        return DataCloudConnection.of(channel, new Properties());
     }
 
     public static DataCloudConnection getHyperQueryConnection() {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/EmittedHeaderTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/EmittedHeaderTest.java
@@ -122,7 +122,7 @@ public class EmittedHeaderTest {
             channel.intercept(tracer);
         }
 
-        try (val connection = DataCloudConnection.of(channel, properties, true);
+        try (val connection = DataCloudConnection.of(channel, properties);
                 val statement = connection.createStatement().unwrap(DataCloudStatement.class)) {
             statement.executeAsyncQuery("select 1");
         }

--- a/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
+++ b/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
@@ -153,13 +153,7 @@ public class DataCloudJDBCDriver implements Driver {
         val dataspaceClient = new DataspaceClient(properties, tokenProcessor);
 
         return DataCloudConnection.of(
-                builder,
-                properties,
-                authInterceptor,
-                tokenProcessor::getLakehouse,
-                dataspaceClient,
-                connectionString,
-                true);
+                builder, properties, authInterceptor, tokenProcessor::getLakehouse, dataspaceClient, connectionString);
     }
 
     static void addClientUsernameIfRequired(Properties properties) {


### PR DESCRIPTION
We realized that allowing someone to opt-out of `closeChannelWithConnection` when constructing a `DataCloudConnection` with a `ManagedChannelBuilder` would cause the driver to leak that connection.

This change removes those overloads and just passes `true` to the one build method that accepts a `DataCloudJdbcManagedChannel` and `closeChannelWithConnection`, therefore someone who has a handle to the channel and knows they opted out of automatic cleanup can clean up their channel later.