### PR TITLE
Remove `listener` from `StreamingResultSet`

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudResultSet.java
@@ -24,6 +24,4 @@ public interface DataCloudResultSet extends ResultSet {
     String getQueryId();
 
     Stream<DataCloudQueryStatus> getQueryStatus() throws DataCloudJDBCException;
-
-    boolean isReady() throws DataCloudJDBCException;
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingResultSetTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingResultSetTest.java
@@ -120,8 +120,6 @@ public class StreamingResultSetTest {
             assertThat(s.getRowCount()).isEqualTo(large);
         });
 
-        assertThat(rs.isReady()).as("result set is ready").isTrue();
-
         while (rs.next()) {
             assertEachRowIsTheSame(rs, witnessed);
             assertThat(rs.getRow()).isEqualTo(witnessed.get());

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListenerTest.java
@@ -77,7 +77,6 @@ public class AdaptiveQueryStatusListenerTest extends HyperGrpcTestBase {
 
         assertThat(resultSet).isNotNull();
         assertThat(resultSet.getQueryId()).isEqualTo(queryId);
-        assertThat(resultSet.isReady()).isTrue();
 
         resultSet.next();
         assertThat(resultSet.getInt("id")).isEqualTo(alice.getId());

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
@@ -126,7 +126,6 @@ class AsyncQueryStatusListenerTest extends HyperGrpcTestBase {
         val resultSet = sut(query).generateResultSet();
         assertThat(resultSet).isNotNull();
         assertThat(resultSet.getQueryId()).isEqualTo(queryId);
-        assertThat(resultSet.isReady()).isTrue();
 
         resultSet.next();
         assertThat(resultSet.getInt(1)).isEqualTo(studentId);


### PR DESCRIPTION
This commit de-obfuscates the code inside the `StreamingResultSet`.

The `listener` was always set to an `AlreadyReadyNoopListener` which is essentially nothing else than a wrapper around the query-id. All its other variables (e.g., `ready`) were hardcoded. Maybe this abstraction served some actual purpose at some earlier time, but by now it was only obfuscating the code.

This commit removes that code obfuscation.

After deobfuscation, it became obvious that `DataCloudResultSet.isReady` was essentially hard-coded to true. As such, I am also removing that function in this commit.