### PR TITLE
Remove `QueryStatusListener.get{Status,Query}`

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java
@@ -49,9 +49,6 @@ public class AdaptiveQueryStatusListener implements QueryStatusListener {
     @Getter
     private final String queryId;
 
-    @Getter
-    private final String query;
-
     private final HyperGrpcClientExecutor client;
 
     private final Duration timeout;
@@ -68,7 +65,7 @@ public class AdaptiveQueryStatusListener implements QueryStatusListener {
 
             log.info("Executing adaptive query. queryId={}, timeout={}", queryId, timeout);
 
-            return new AdaptiveQueryStatusListener(queryId, query, client, timeout, response);
+            return new AdaptiveQueryStatusListener(queryId, client, timeout, response);
         } catch (StatusRuntimeException ex) {
             throw QueryExceptionHandler.createQueryException(query, ex);
         }
@@ -82,19 +79,10 @@ public class AdaptiveQueryStatusListener implements QueryStatusListener {
 
             log.info("Executing adaptive query. queryId={}, timeout={}", queryId, timeout);
 
-            return new RowBasedAdaptiveQueryStatusListener(queryId, query, client, response);
+            return new RowBasedAdaptiveQueryStatusListener(queryId, client, response);
         } catch (StatusRuntimeException ex) {
             throw QueryExceptionHandler.createQueryException(query, ex);
         }
-    }
-
-    @Override
-    public String getStatus() throws DataCloudJDBCException {
-        return client.getQueryStatus(queryId)
-                .map(DataCloudQueryStatus::getCompletionStatus)
-                .map(Enum::name)
-                .findFirst()
-                .orElse("UNKNOWN");
     }
 
     @Override
@@ -155,23 +143,11 @@ public class AdaptiveQueryStatusListener implements QueryStatusListener {
         @Getter
         private final String queryId;
 
-        @Getter
-        private final String query;
-
         private final HyperGrpcClientExecutor client;
 
         private final Iterator<ExecuteQueryResponse> response;
 
         private final AtomicReference<DataCloudQueryStatus> lastStatus = new AtomicReference<>();
-
-        @Override
-        public String getStatus() throws DataCloudJDBCException {
-            return client.getQueryStatus(queryId)
-                    .map(DataCloudQueryStatus::getCompletionStatus)
-                    .map(Enum::name)
-                    .findFirst()
-                    .orElse("UNKNOWN");
-        }
 
         @Override
         public DataCloudResultSet generateResultSet() throws DataCloudJDBCException {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListener.java
@@ -41,9 +41,6 @@ public class AsyncQueryStatusListener implements QueryStatusListener {
     @Getter
     private final String queryId;
 
-    @Getter
-    private final String query;
-
     private final HyperGrpcClientExecutor client;
 
     private final Duration timeout;
@@ -58,22 +55,12 @@ public class AsyncQueryStatusListener implements QueryStatusListener {
 
             return AsyncQueryStatusListener.builder()
                     .queryId(queryId)
-                    .query(query)
                     .client(client)
                     .timeout(timeout)
                     .build();
         } catch (StatusRuntimeException ex) {
             throw QueryExceptionHandler.createQueryException(query, ex);
         }
-    }
-
-    @Override
-    public String getStatus() throws DataCloudJDBCException {
-        return client.getQueryStatus(queryId)
-                .map(DataCloudQueryStatus::getCompletionStatus)
-                .map(Enum::name)
-                .findFirst()
-                .orElse("UNKNOWN");
     }
 
     @Override

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListener.java
@@ -23,10 +23,6 @@ import salesforce.cdp.hyperdb.v1.QueryResult;
 
 @Deprecated
 public interface QueryStatusListener {
-    String getQuery();
-
-    String getStatus() throws DataCloudJDBCException;
-
     String getQueryId();
 
     DataCloudResultSet generateResultSet() throws DataCloudJDBCException;

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListenerTest.java
@@ -54,16 +54,6 @@ public class AdaptiveQueryStatusListenerTest extends HyperGrpcTestBase {
 
     @SneakyThrows
     @Test
-    void itWillWaitUntilResultsProducedOrFinishedToProduceStatus() {
-        val queryId = UUID.randomUUID().toString();
-        setupExecuteQuery(queryId, query, mode, executeQueryResponse(queryId, null, 1));
-        setupGetQueryInfo(queryId, QueryStatus.CompletionStatus.RESULTS_PRODUCED, 3);
-        val listener = sut(query);
-        QueryStatusListenerAssert.assertThat(listener).hasStatus(QueryStatus.CompletionStatus.RESULTS_PRODUCED.name());
-    }
-
-    @SneakyThrows
-    @Test
     void itReturnsNoChunkResults() {
         val queryId = UUID.randomUUID().toString();
         setupExecuteQuery(

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
@@ -36,8 +36,6 @@ import org.grpcmock.junit5.InProcessGrpcMockExtension;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import salesforce.cdp.hyperdb.v1.QueryParam;
 import salesforce.cdp.hyperdb.v1.QueryStatus;
 
@@ -45,18 +43,6 @@ import salesforce.cdp.hyperdb.v1.QueryStatus;
 class AsyncQueryStatusListenerTest extends HyperGrpcTestBase {
     private final String query = "select * from stuff";
     private final QueryParam.TransferMode mode = QueryParam.TransferMode.ASYNC;
-
-    @SneakyThrows
-    @ParameterizedTest
-    @CsvSource({"0, RUNNING", "1, RESULTS_PRODUCED", "2, FINISHED"})
-    void itCanGetStatus(int value, String expected) {
-        val queryId = UUID.randomUUID().toString();
-        setupExecuteQuery(queryId, query, mode);
-        val listener = sut(query);
-
-        setupGetQueryInfo(queryId, QueryStatus.CompletionStatus.forNumber(value));
-        assertThat(listener.getStatus()).isEqualTo(expected);
-    }
 
     @SneakyThrows
     @Test

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerAssert.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerAssert.java
@@ -15,7 +15,6 @@
  */
 package com.salesforce.datacloud.jdbc.core.listener;
 
-import lombok.SneakyThrows;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.util.Objects;
 
@@ -46,30 +45,6 @@ public class QueryStatusListenerAssert extends AbstractObjectAssert<QueryStatusL
     }
 
     /**
-     * Verifies that the actual QueryStatusListener's query is equal to the given one.
-     *
-     * @param query the given query to compare the actual QueryStatusListener's query to.
-     * @return this assertion object.
-     * @throws AssertionError - if the actual QueryStatusListener's query is not equal to the given one.
-     */
-    public QueryStatusListenerAssert hasQuery(String query) {
-        // check that actual QueryStatusListener we want to make assertions on is not null.
-        isNotNull();
-
-        // overrides the default error message with a more explicit one
-        String assertjErrorMessage = "\nExpecting query of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
-
-        // null safe check
-        String actualQuery = actual.getQuery();
-        if (!Objects.areEqual(actualQuery, query)) {
-            failWithMessage(assertjErrorMessage, actual, query, actualQuery);
-        }
-
-        // return the current assertion for method chaining
-        return this;
-    }
-
-    /**
      * Verifies that the actual QueryStatusListener's queryId is equal to the given one.
      *
      * @param queryId the given queryId to compare the actual QueryStatusListener's queryId to.
@@ -87,31 +62,6 @@ public class QueryStatusListenerAssert extends AbstractObjectAssert<QueryStatusL
         String actualQueryId = actual.getQueryId();
         if (!Objects.areEqual(actualQueryId, queryId)) {
             failWithMessage(assertjErrorMessage, actual, queryId, actualQueryId);
-        }
-
-        // return the current assertion for method chaining
-        return this;
-    }
-
-    /**
-     * Verifies that the actual QueryStatusListener's status is equal to the given one.
-     *
-     * @param status the given status to compare the actual QueryStatusListener's status to.
-     * @return this assertion object.
-     * @throws AssertionError - if the actual QueryStatusListener's status is not equal to the given one.
-     */
-    @SneakyThrows
-    public QueryStatusListenerAssert hasStatus(String status) {
-        // check that actual QueryStatusListener we want to make assertions on is not null.
-        isNotNull();
-
-        // overrides the default error message with a more explicit one
-        String assertjErrorMessage = "\nExpecting status of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
-
-        // null safe check
-        String actualStatus = actual.getStatus();
-        if (!Objects.areEqual(actualStatus, status)) {
-            failWithMessage(assertjErrorMessage, actual, status, actualStatus);
         }
 
         // return the current assertion for method chaining

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerTest.java
@@ -53,13 +53,13 @@ class QueryStatusListenerTest extends HyperGrpcTestBase {
 
     @ParameterizedTest
     @MethodSource("supported")
-    void itKeepsTrackOfQueryAndQueryId(QueryParam.TransferMode mode) {
+    void itKeepsTrackOfQueryId(QueryParam.TransferMode mode) {
         val query = this.query + UUID.randomUUID();
         val queryId = UUID.randomUUID().toString();
 
         setupExecuteQuery(queryId, query, mode);
         val listener = sut(query, mode);
 
-        QueryStatusListenerAssert.assertThat(listener).hasQueryId(queryId).hasQuery(query);
+        QueryStatusListenerAssert.assertThat(listener).hasQueryId(queryId);
     }
 }


### PR DESCRIPTION
Both functions were used exclusively in test cases and served no actual
purpose. Also the two test cases served no purpose:

* `itCanGetStatus` and `itKeepsTrackOfQueryAndQueryId` only checked that
  both functions were implemented correctly.
* `itWillWaitUntilResultsProducedOrFinishedToProduceStatus` did not
  actually test any waiting, despite what the test case name claimed.
  Instead, the test expectations were setup, such that the `hasStatus`
  was fulfilled already on the first call, making this another call
  which essentially only checked that `getStatus` actually gets the
  status
