### PR TITLE
fix: force MetadataResultSet to be forward only

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/MetadataResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/MetadataResultSet.java
@@ -18,11 +18,11 @@ package com.salesforce.datacloud.jdbc.core;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
+import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.TimeZone;
-import lombok.experimental.UtilityClass;
 import lombok.val;
 import org.apache.calcite.avatica.AvaticaResultSet;
 import org.apache.calcite.avatica.AvaticaResultSetMetaData;
@@ -30,8 +30,18 @@ import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.QueryState;
 
-@UtilityClass
-public class MetadataResultSet {
+public class MetadataResultSet extends AvaticaResultSet {
+    public MetadataResultSet(
+            AvaticaStatement statement,
+            QueryState state,
+            Meta.Signature signature,
+            ResultSetMetaData resultSetMetaData,
+            TimeZone timeZone,
+            Meta.Frame firstFrame)
+            throws SQLException {
+        super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
+    }
+
     public static AvaticaResultSet of() throws SQLException {
         val signature = new Meta.Signature(
                 ImmutableList.of(), null, ImmutableList.of(), ImmutableMap.of(), null, Meta.StatementType.SELECT);
@@ -56,11 +66,26 @@ public class MetadataResultSet {
             throws SQLException {
         AvaticaResultSet result;
         try {
-            result = new AvaticaResultSet(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
+            result = new MetadataResultSet(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
         } catch (SQLException e) {
             throw new DataCloudJDBCException(e);
         }
         result.execute2(new MetadataCursor(data), signature.columns);
         return result;
+    }
+
+    @Override
+    public int getType() {
+        return ResultSet.TYPE_FORWARD_ONLY;
+    }
+
+    @Override
+    public int getConcurrency() {
+        return ResultSet.CONCUR_READ_ONLY;
+    }
+
+    @Override
+    public int getFetchDirection() {
+        return ResultSet.FETCH_FORWARD;
     }
 }


### PR DESCRIPTION
This should fix an issue where tools that make use of DatabaseMetaData expect a more complete result set. Unfortunately, the Avatica ResultSet is difficult to make forward only through its constructor. So instead, we extend that ResultSet and override the forward only related methods.