### PR TITLE
feat: expose polling for a query status by arbitrary predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 With the Salesforce Data Cloud JDBC driver you can efficiently query millions of rows of data with low latency, and perform bulk data extractions.
 This driver is read-only, forward-only, and requires Java 8 or greater. It uses the new [Data Cloud Query API SQL syntax](https://developer.salesforce.com/docs/data/data-cloud-query-guide/references/dc-sql-reference/data-cloud-sql-context.html).
 
+## Example usage
+
+We have a suite of tests that demonstrate preferred usage patterns when using APIs that are outside of the JDBC specification.
+Please check out the [examples here](jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples).
 
 ## Getting started
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
 
-hyperApiVersion=0.0.21408.rf5a406c0
+hyperApiVersion=0.0.22106.r7822c4e1
 
 # Revision here is what is used when producing local and snapshot builds,
 # it is ignored for releases which instead use the tag

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,6 @@ org.gradle.caching=true
 
 hyperApiVersion=0.0.21408.rf5a406c0
 
-revision=0.27.0
+# Revision here is what is used when producing local and snapshot builds,
+# it is ignored for releases which instead use the tag
+revision=0.29.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ mockito = "4.11.0"
 slf4j = "[2.0.7, 3.0)"
 plugin-com-google-protobuf = "0.9.4"
 plugin-com-gradleup-shadow = "8.3.6"
-plugin-freefair-lombok = "8.13"
+plugin-freefair-lombok = "8.13.1"
 plugin-build-buf = "0.10.2"
 
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientExecutor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientExecutor.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -132,9 +133,10 @@ public class HyperGrpcClientExecutor {
         return DataCloudQueryPolling.waitForChunksAvailable(stub, queryId, offset, limit, timeout, allowLessThan);
     }
 
-    public DataCloudQueryStatus waitForResultsProduced(String queryId, Duration timeout) throws DataCloudJDBCException {
+    public DataCloudQueryStatus waitForQueryStatus(
+            String queryId, Duration timeout, Predicate<DataCloudQueryStatus> predicate) throws DataCloudJDBCException {
         val stub = getStub(queryId);
-        return DataCloudQueryPolling.waitForResultsProduced(stub, queryId, timeout);
+        return DataCloudQueryPolling.waitForQueryStatus(stub, queryId, timeout, predicate);
     }
 
     public Stream<DataCloudQueryStatus> getQueryStatus(String queryId) throws DataCloudJDBCException {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListener.java
@@ -134,7 +134,7 @@ public class AdaptiveQueryStatusListener implements QueryStatusListener {
             return Stream.empty();
         }
 
-        val status = client.waitForResultsProduced(queryId, timeout);
+        val status = client.waitForQueryStatus(queryId, timeout, DataCloudQueryStatus::allResultsProduced);
 
         if (!status.allResultsProduced()) {
             throw new DataCloudJDBCException(BEFORE_READY + ". queryId=" + queryId + ", timeout=" + timeout);

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListener.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListener.java
@@ -83,7 +83,7 @@ public class AsyncQueryStatusListener implements QueryStatusListener {
 
     @Override
     public Stream<QueryResult> stream() throws DataCloudJDBCException {
-        val status = client.waitForResultsProduced(queryId, timeout);
+        val status = client.waitForQueryStatus(queryId, timeout, DataCloudQueryStatus::allResultsProduced);
         val iterator = ChunkBased.of(client, queryId, 0, status.getChunkCount(), false);
 
         return StreamUtilities.toStream(iterator);

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPolling.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPolling.java
@@ -98,12 +98,6 @@ public class DataCloudQueryPolling {
         }
     }
 
-    public static DataCloudQueryStatus waitForResultsProduced(
-            HyperServiceGrpc.HyperServiceBlockingStub stub, String queryId, Duration timeout)
-            throws DataCloudJDBCException {
-        return waitForQueryStatus(stub, queryId, timeout, DataCloudQueryStatus::allResultsProduced);
-    }
-
     public static DataCloudQueryStatus waitForQueryStatus(
             HyperServiceGrpc.HyperServiceBlockingStub stub,
             String queryId,

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementFunctionalTest.java
@@ -51,7 +51,7 @@ public class DataCloudStatementFunctionalTest {
             statement.cancel();
 
             assertThatThrownBy(() -> client.getQueryStatus(queryId).collect(Collectors.toList()))
-                    .hasMessage("FAILED_PRECONDITION: canceled");
+                    .hasMessageStartingWith("FAILED_PRECONDITION: canceled");
         }
     }
 
@@ -74,7 +74,7 @@ public class DataCloudStatementFunctionalTest {
             statement.cancel();
 
             assertThatThrownBy(() -> client.getQueryStatus(queryId).collect(Collectors.toList()))
-                    .hasMessage("FAILED_PRECONDITION: canceled");
+                    .hasMessageStartingWith("FAILED_PRECONDITION: canceled");
         }
     }
 
@@ -95,7 +95,7 @@ public class DataCloudStatementFunctionalTest {
             connection.cancelQuery(queryId);
 
             assertThatThrownBy(() -> client.getQueryStatus(queryId).collect(Collectors.toList()))
-                    .hasMessage("FAILED_PRECONDITION: canceled");
+                    .hasMessageStartingWith("FAILED_PRECONDITION: canceled");
         }
     }
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/ChunkBasedTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/ChunkBasedTest.java
@@ -80,7 +80,7 @@ class ChunkBasedTest {
                 .isInstanceOf(DataCloudJDBCException.class)
                 .hasMessage("Failed to load next batch")
                 .hasCauseInstanceOf(StatusRuntimeException.class)
-                .hasRootCauseMessage("OUT_OF_RANGE: The requested chunk id '1' is out of range");
+                .hasRootCauseMessage("INVALID_ARGUMENT: The requested chunk id '1' is out of range");
     }
 
     @SneakyThrows

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/RowBasedTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/RowBasedTest.java
@@ -121,7 +121,7 @@ public class RowBasedTest {
         assertThatThrownBy(() -> sut(tiny, 0, tinySize * 3, RowBased.Mode.FULL_RANGE))
                 .hasRootCauseInstanceOf(StatusRuntimeException.class)
                 .hasRootCauseMessage(String.format(
-                        "OUT_OF_RANGE: Request out of range: The specified offset is %d, but only %d tuples are available",
+                        "INVALID_ARGUMENT: Request out of range: The specified offset is %d, but only %d tuples are available",
                         tinySize, tinySize));
     }
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/ResultScanTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/ResultScanTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.examples;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.salesforce.datacloud.jdbc.core.DataCloudConnection;
+import com.salesforce.datacloud.jdbc.core.DataCloudPreparedStatement;
+import com.salesforce.datacloud.jdbc.hyper.HyperTestBase;
+import com.salesforce.datacloud.query.v3.DataCloudQueryStatus;
+import io.grpc.ManagedChannelBuilder;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Slf4j
+@ExtendWith(HyperTestBase.class)
+public class ResultScanTest {
+    @SneakyThrows
+    @Test
+    void testResultScanWithWait() {
+        int size = 10;
+        Properties properties = new Properties();
+        ManagedChannelBuilder<?> channel = ManagedChannelBuilder.forAddress(
+                        "127.0.0.1", HyperTestBase.getInstancePort())
+                .usePlaintext();
+
+        final String queryId;
+
+        try (val conn = DataCloudConnection.of(channel, properties);
+                val stmt = conn.prepareStatement("SELECT a from generate_series(1,?) a")
+                        .unwrap(DataCloudPreparedStatement.class)) {
+            stmt.setInt(1, size);
+            stmt.execute();
+            queryId = stmt.getQueryId();
+        }
+
+        val results = new ArrayList<Integer>();
+
+        try (val conn = DataCloudConnection.of(channel, properties);
+                val stmt = conn.createStatement()) {
+            conn.waitForQueryStatus(queryId, Duration.ofDays(1), DataCloudQueryStatus::isExecutionFinished);
+
+            val rs = stmt.executeQuery(String.format("SELECT * from result_scan('%s')", queryId));
+
+            while (rs.next()) {
+                results.add(rs.getInt(1));
+            }
+
+            assertThat(results)
+                    .containsExactlyInAnyOrderElementsOf(
+                            IntStream.rangeClosed(1, size).boxed().collect(Collectors.toList()));
+        }
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/HyperServerProcess.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/HyperServerProcess.java
@@ -66,7 +66,7 @@ public class HyperServerProcess implements AutoCloseable {
                 .toFile();
 
         if (!executable.exists()) {
-            Assertions.fail("hyperd executable couldn't be found, have you run mvn process-test-resources? expected="
+            Assertions.fail("hyperd executable couldn't be found, have you run `gradle extractHyper`? expected="
                     + executable.getAbsolutePath());
         }
 

--- a/jdbc-core/src/test/resources/hyper.yaml
+++ b/jdbc-core/src/test/resources/hyper.yaml
@@ -7,4 +7,3 @@ grpc_persist_results: true
 log_pipelines: true
 experimental_pg_sleep: true
 result_scan_enabled: true
-log_shared_storage: true

--- a/jdbc-core/src/test/resources/hyper.yaml
+++ b/jdbc-core/src/test/resources/hyper.yaml
@@ -3,7 +3,8 @@ skip-license: true
 strict-settings-mode: true
 language: en_US
 no-password: true
-use_v3_new_endpoints: true
 grpc_persist_results: true
 log_pipelines: true
 experimental_pg_sleep: true
+result_scan_enabled: true
+log_shared_storage: true


### PR DESCRIPTION
This will allow callers to wait for a query to satisfy their own criteria while also benefiting from the existing retry logic that is already in place for waiting for chunks or rows.