### PR TITLE
remove unused 3pl for jdbc-core

### DIFF
--- a/jdbc-core/build.gradle.kts
+++ b/jdbc-core/build.gradle.kts
@@ -19,8 +19,6 @@ dependencies {
 
     implementation(libs.guava)
 
-    implementation(libs.jackson.databind)
-
     implementation(libs.failsafe)
 
     implementation(libs.apache.commons.lang3)


### PR DESCRIPTION
I noticed jackson databind wasn't being used in jdbc-core anymore so I pulled that out of the build file