### PR TITLE
feat: Improved query timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ openssl pkcs8 -topk8 -nocrypt -in keypair.key -out private.key
 This section describes details around potential pitfalls / ambiguities related to JDBC
 - The standard offers two types for fixed point decimals (`NUMERIC` and `DECIMAL`), this driver uses `DECIMAL` to represent such values
 - The JDBC standard describes that `getObject` for a `SHORT` should return an `Integer`. Due to a current limitation we for now return a `Short` object. This will likely be fixed in a future version of the JDBC driver.
+- The query timeout enforcement is done on the server side for both normal as well as async execution. To provide a safety net with regards to network problems the driver locally also does a delayed enforcement for normal query executions. The default delay is `5` seconds - which typically shouldn't be relevant as in normal circumstances the server will enforce the timeout. The local enforcement delay can be configured through the `queryTimeoutLocalEnforcementDelay` property
 
 ### Optional configuration
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StatementProperties.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StatementProperties.java
@@ -36,10 +36,12 @@ public class StatementProperties {
     @With
     @Builder.Default
     private final Duration queryTimeout = Duration.ZERO;
-    // The amount of time that the local driver waits in additional to the query timeout for the server-side
-    // cancellation. This is used to account for network latency and ensure the server has time to produce and transmit
-    // the (more helpful server-side) error message. The 5 seconds were chosen based off a guess to also accommodate
-    // very slow public internet connections. A zero duration is interpreted as zero.
+    /**
+     * The amount of time that the local driver waits in additional to the query timeout for the server-side
+     * cancellation. This is used to account for network latency and ensure the server has time to produce and transmit
+     * the (more helpful server-side) error message. The 5 seconds were chosen based off a guess to also accommodate
+     * very slow public internet connections. A zero duration is interpreted as zero.
+     */
     @With
     @Builder.Default
     private final Duration queryTimeoutLocalEnforcementDelay = Duration.ofSeconds(5);

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StatementProperties.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StatementProperties.java
@@ -36,6 +36,13 @@ public class StatementProperties {
     @With
     @Builder.Default
     private final Duration queryTimeout = Duration.ZERO;
+    // The amount of time that the local driver waits in additional to the query timeout for the server-side
+    // cancellation. This is used to account for network latency and ensure the server has time to produce and transmit
+    // the (more helpful server-side) error message. The 5 seconds were chosen based off a guess to also accommodate
+    // very slow public internet connections. A zero duration is interpreted as zero.
+    @With
+    @Builder.Default
+    private final Duration queryTimeoutLocalEnforcementDelay = Duration.ofSeconds(5);
 
     /**
      * The query settings to use for the connection
@@ -65,7 +72,19 @@ public class StatementProperties {
                     builder.queryTimeout(timeout);
                 }
             } catch (NumberFormatException e) {
-                throw new DataCloudJDBCException("Failed to parse queryTimeout: " + e.getMessage());
+                throw new DataCloudJDBCException("Failed to parse `queryTimeout` property: " + e.getMessage());
+            }
+        }
+
+        // The query timeout local enforcement delay property
+        String queryTimeoutLocalEnforcementDelayStr = props.getProperty("queryTimeoutLocalEnforcementDelay");
+        if (queryTimeoutLocalEnforcementDelayStr != null) {
+            try {
+                Duration delay = Duration.ofSeconds(Integer.parseInt(queryTimeoutLocalEnforcementDelayStr));
+                builder.queryTimeoutLocalEnforcementDelay(delay);
+            } catch (NumberFormatException e) {
+                throw new DataCloudJDBCException(
+                        "Failed to parse `queryTimeoutLocalEnforcementDelay` property: " + e.getMessage());
             }
         }
 
@@ -75,6 +94,10 @@ public class StatementProperties {
             if (key.startsWith("querySetting.")) {
                 String settingKey = key.substring("querySetting.".length());
                 String settingValue = props.getProperty(key);
+                if ("query_timeout".equalsIgnoreCase(settingKey)) {
+                    throw new DataCloudJDBCException(
+                            "`query_timeout` is not an allowed `querySetting` subkey, use the `queryTimeout` property instead");
+                }
                 querySettings.put(settingKey, settingValue);
             }
         }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/Constants.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/Constants.java
@@ -16,11 +16,6 @@
 package com.salesforce.datacloud.jdbc.util;
 
 public final class Constants {
-    /**
-     * Because Java doesn't have the concept of an infinite duration we'll use 3 days as the default timeout
-     */
-    public static final int INFINITE_QUERY_TIMEOUT = 259200;
-
     public static final String LOGIN_URL = "loginURL";
 
     // Property constants

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/Deadline.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/Deadline.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.util;
+
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+/**
+ * Utility class that handles logic around enforcing timeouts on API calls. It provides simple access
+ * to the remaining time based off an initial timeout. This allows to easily enforce a timeout
+ * across multiple network calls.
+ */
+@Builder(access = AccessLevel.PRIVATE)
+public class Deadline {
+    // The deadline in nanoseconds.
+    private final long deadline;
+
+    /**
+     * Initialize a deadline with the given timeout.
+     * @param timeout The timeout to enforce. A duration of zero means an infinite deadline and no timeout.
+     * @return The deadline.
+     */
+    public static Deadline of(Duration timeout) {
+        // Handle infinite / no timeout case
+        if (timeout.isZero()) {
+            // We can't use Long.MAX_VALUE here as it results in a remaining time that is too large for netty.
+            // Thus for practical pruposes we say that an infitine deadline is 10 days from now.
+            timeout = Duration.ofDays(10);
+        }
+        return Deadline.builder().deadline(currentTime() + timeout.toNanos()).build();
+    }
+
+    /**
+     * Returns the remaining time until the deadline is reached.
+     * @return The remaining time until the deadline is reached.
+     */
+    public Duration getRemaining() {
+        long remaining = deadline - currentTime();
+        return Duration.ofNanos(remaining);
+    }
+
+    /**
+     * Returns true if the deadline has passed.
+     * @return True if the deadline has passed, false otherwise.
+     */
+    public boolean hasPassed() {
+        return currentTime() >= deadline;
+    }
+
+    /**
+     * We are using nano time here because it provides a monotonic clock that never goes backwards or
+     * jumps due to system clock adjustments / leap seconds / ...
+     * @return The current time in nanoseconds.
+     */
+    private static long currentTime() {
+        return System.nanoTime();
+    }
+}

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/QueryTimeout.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/QueryTimeout.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.util;
+
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * This class captures all the information needed to enforce a query timeout.
+ * <p>
+ * The serverQueryTimeout is the timeout that should be enforced by the server.
+ * <p>
+ * The localDeadline is the deadline that should be enforced by the JDBC driver.
+ * <p>
+ * The localDeadline is the server timeout plus a "slack" buffer to account for network latency and ensure the server has time to
+ * produce and transmit the error message.
+ */
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class QueryTimeout {
+    // This is the query timeout duration that should be enforced server-side
+    private final Duration serverQueryTimeout;
+    /*
+     * This is the deadline that should be enforced by the JDBC driver. Generally server-enforced timeouts are preferable as the server
+     * gets the chance to produce detailed error messages. The driver still enforces a timeout locally to avoid blocking the client.
+     * The local deadline is the server timeout plus a "slack" buffer to account for network latency and ensure the server has time
+     * to produce and transmit the error message.
+     */
+    private final Deadline localDeadline;
+
+    /**
+     * Creates a QueryTimeout object based off the JDBC query timeout.
+     * @param queryTimeout The query timeout duration, zero is interpreted as infinite timeout
+     * @return A QueryTimeout object
+     */
+    public static QueryTimeout of(Duration queryTimeout, Duration localEnforcementDelay) {
+        if (queryTimeout.isZero()) {
+            // When the query timeout is zero we'll set both server query timeout
+            // and local deadline to be effectively infinite.
+            return QueryTimeout.builder()
+                    .serverQueryTimeout(Duration.ZERO)
+                    .localDeadline(Deadline.of(Duration.ZERO))
+                    .build();
+        } else {
+            return QueryTimeout.builder()
+                    .serverQueryTimeout(queryTimeout)
+                    .localDeadline(Deadline.of(queryTimeout.plus(localEnforcementDelay)))
+                    .build();
+        }
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionFunctionalTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import com.salesforce.datacloud.jdbc.hyper.HyperTestBase;
 import com.salesforce.datacloud.jdbc.util.HyperLogScope;
 import java.sql.SQLException;
+import java.time.Duration;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class DataCloudConnectionFunctionalTest {
             val rs = hyperLogScope.executeQuery(
                     "select CAST(v->>'requested-timeout' as DOUBLE PRECISION)from hyper_log WHERE k='grpc-query-received'");
             rs.next();
-            assertThat(rs.getDouble(1)).isGreaterThan(1e12);
+            assertThat(rs.getDouble(1)).isGreaterThan(Duration.ofDays(5).toMillis() / 1000.0);
         }
         hyperLogScope.close();
     }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientTest.java
@@ -18,7 +18,9 @@ package com.salesforce.datacloud.jdbc.core;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.google.protobuf.ByteString;
+import com.salesforce.datacloud.jdbc.util.QueryTimeout;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.Iterator;
 import org.grpcmock.GrpcMock;
 import org.junit.jupiter.api.Test;
@@ -42,7 +44,8 @@ class HyperGrpcClientTest extends HyperGrpcTestBase {
                 .willReturn(chunk1));
 
         String query = "SELECT * FROM test";
-        Iterator<ExecuteQueryResponse> queryResultIterator = hyperGrpcClient.executeQuery(query);
+        Iterator<ExecuteQueryResponse> queryResultIterator =
+                hyperGrpcClient.executeQuery(query, QueryTimeout.of(Duration.ZERO, Duration.ZERO));
         assertDoesNotThrow(() -> {
             while (queryResultIterator.hasNext()) {
                 queryResultIterator.next();

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertiesTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertiesTest.java
@@ -125,6 +125,7 @@ class PropertiesTest extends HyperGrpcTestBase {
         Properties properties = new Properties();
         properties.setProperty("queryTimeout", "invalid");
         val exception = assertThrows(DataCloudJDBCException.class, () -> ConnectionProperties.of(properties));
-        assertThat(exception.getMessage()).contains("Failed to parse queryTimeout: For input string: \"invalid\"");
+        assertThat(exception.getMessage())
+                .contains("Failed to parse `queryTimeout` property: For input string: \"invalid\"");
     }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryTimeoutTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryTimeoutTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
+import com.salesforce.datacloud.jdbc.hyper.HyperTestBase;
+import com.salesforce.datacloud.jdbc.util.HyperLogScope;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(HyperTestBase.class)
+class QueryTimeoutTest {
+
+    @Test
+    void testQueryTimeoutPropagation() throws SQLException {
+        // Test that query timeout is propagated to the server-side
+        try (Connection connection = HyperTestBase.getHyperQueryConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.setQueryTimeout(10);
+                ResultSet resultSet = statement.executeQuery("SHOW query_timeout");
+                resultSet.next();
+                assertEquals(resultSet.getString(1), "10s");
+            }
+        }
+    }
+
+    @Test
+    void testLocalEnforcementDoesntImpactServerTimeout() throws SQLException {
+        // Test that local enforcement delay does not affect the server-side timeout
+        Properties props = new Properties();
+        props.setProperty("queryTimeoutLocalEnforcementDelay", "5");
+        try (Connection connection = HyperTestBase.getHyperQueryConnection(props)) {
+            connection.setNetworkTimeout(null, 100000);
+            try (Statement statement = connection.createStatement()) {
+                statement.setQueryTimeout(10);
+                ResultSet resultSet = statement.executeQuery("SHOW query_timeout");
+                resultSet.next();
+                assertEquals(resultSet.getString(1), "10s");
+            }
+        }
+    }
+
+    @Test
+    void testNetworkTimeoutDoesntImpactServerTimeout() throws SQLException {
+        // Test that network timeout does not affect the server-side timeout
+        try (Connection connection = HyperTestBase.getHyperQueryConnection()) {
+            connection.setNetworkTimeout(null, 100000);
+            try (Statement statement = connection.createStatement()) {
+                statement.setQueryTimeout(10);
+                ResultSet resultSet = statement.executeQuery("SHOW query_timeout");
+                resultSet.next();
+                assertEquals(resultSet.getString(1), "10s");
+            }
+        }
+    }
+
+    @Test
+    void testServerQueryTimeoutIsHandledCorrectly() throws SQLException {
+        // Verify that in normal operations the server-side is canceling the query with the timeout (and not the client)
+        try (Connection connection = HyperTestBase.getHyperQueryConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.setQueryTimeout(1);
+                DataCloudJDBCException ex = assertThrows(
+                        DataCloudJDBCException.class, () -> statement.executeQuery("SELECT pg_sleep(100)"));
+                // Check that the exception contains the error message that Hyper server produces on server-side
+                // timeouts
+                assertThat(ex.getMessage()).contains("canceled by query timeout");
+                assertEquals("57014", ex.getSQLState());
+            }
+        }
+    }
+
+    @Test
+    void testNetworkTimeoutDoesntInterfereWithLocalEnforcement() throws SQLException {
+        // Both local enforcement and network timeout integrate with the gRPC deadline mechanism.
+        // This test verifies that they don't interfere with each other. If the local enforcement
+        // deadline is set to 10 seconds and the network timeout is set to 100 seconds, the gRPC
+        // deadline should not be 100 seconds but rather the 10 seconds.
+        HyperLogScope logScope = new HyperLogScope();
+        Properties props = logScope.getProperties();
+        props.setProperty("queryTimeoutLocalEnforcementDelay", "10");
+        try (Connection connection = HyperTestBase.getHyperQueryConnection(props)) {
+            connection.setNetworkTimeout(null, 100000);
+            try (Statement statement = connection.createStatement()) {
+                statement.setQueryTimeout(10);
+                statement.executeQuery("SHOW query_timeout");
+            }
+        }
+
+        // Verify that the gRPC deadline is far below the 100 seconds that the network timeout is set to.
+        ResultSet resultSet = logScope.executeQuery(
+                "select CAST(v->>'requested-timeout' as DOUBLE PRECISION)from hyper_log WHERE k='grpc-query-received'");
+        resultSet.next();
+        assertThat(resultSet.getDouble(1)).isLessThan(20);
+        logScope.close();
+    }
+
+    @Test
+    void testLocalQueryTimeoutIsHandledCorrectlyWithInitialBlocking() throws SQLException {
+        // This test triggers a scenario where the server is hanging in compilation and thus currently not enforcing
+        // the query timeout. The test verifies that the local enforcement delay is still respected.
+        int queryTimeout = 90;
+        int desiredEnforcementDelay = 1;
+        int localEnforcementDelay = (-1 * queryTimeout) + desiredEnforcementDelay;
+        // This test verifies scenarios where the local query timeout enforcement safety net is handled correctly
+        Properties props = new Properties();
+        props.setProperty("queryTimeoutLocalEnforcementDelay", String.valueOf(localEnforcementDelay));
+        try (Connection connection = HyperTestBase.getHyperQueryConnection(props)) {
+            connection.setNetworkTimeout(null, 5000);
+            try (Statement statement = connection.createStatement()) {
+                statement.setQueryTimeout(queryTimeout);
+                long start = System.nanoTime();
+                assertThrows(
+                        DataCloudJDBCException.class, () -> statement.executeQuery("SELECT 1 WHERE pg_sleep(100)"));
+                long end = System.nanoTime();
+                Duration duration = Duration.ofNanos(end - start);
+                // The query should be canceled within the enforcement delay plus a buffer to account for high load of
+                // the machine
+                // The restriction is still far lower than the query timeout or the sleep.
+                assertThat(duration.toMillis()).isLessThan((desiredEnforcementDelay * 1000) + 5000);
+            }
+        }
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
@@ -23,6 +23,7 @@ import com.salesforce.datacloud.jdbc.core.DataCloudConnection;
 import com.salesforce.datacloud.jdbc.core.DataCloudStatement;
 import com.salesforce.datacloud.jdbc.core.HyperGrpcTestBase;
 import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
+import com.salesforce.datacloud.jdbc.util.QueryTimeout;
 import com.salesforce.datacloud.jdbc.util.RealisticArrowGenerator;
 import java.time.Duration;
 import java.util.NoSuchElementException;
@@ -121,6 +122,6 @@ class AsyncQueryStatusListenerTest extends HyperGrpcTestBase {
 
     @SneakyThrows
     QueryStatusListener sut(String query) {
-        return AsyncQueryStatusListener.of(query, hyperGrpcClient, Duration.ofSeconds(5));
+        return AsyncQueryStatusListener.of(query, hyperGrpcClient, QueryTimeout.of(Duration.ZERO, Duration.ZERO));
     }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerTest.java
@@ -16,6 +16,7 @@
 package com.salesforce.datacloud.jdbc.core.listener;
 
 import com.salesforce.datacloud.jdbc.core.HyperGrpcTestBase;
+import com.salesforce.datacloud.jdbc.util.QueryTimeout;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -38,9 +39,9 @@ class QueryStatusListenerTest extends HyperGrpcTestBase {
     private QueryStatusListener sut(String query, QueryParam.TransferMode mode, Duration timeout) {
         switch (mode) {
             case ASYNC:
-                return AsyncQueryStatusListener.of(query, hyperGrpcClient, timeout);
+                return AsyncQueryStatusListener.of(query, hyperGrpcClient, QueryTimeout.of(timeout, Duration.ZERO));
             case ADAPTIVE:
-                return AdaptiveQueryStatusListener.of(query, hyperGrpcClient, timeout);
+                return AdaptiveQueryStatusListener.of(query, hyperGrpcClient, QueryTimeout.of(timeout, Duration.ZERO));
             default:
                 Assertions.fail("QueryStatusListener mode not supported. mode=" + mode.name());
                 return null;


### PR DESCRIPTION
This change adjusts the query timeout handling from being locally  + gRPC deadline enforced to now primarily being enforced on Hyper server side.
- This allows to return the server side error to the caller. Previously it would either raise an internal error by the JDBC driver or obscure gRPC timeout errors depending on which layer detected the problem first.
- It now also guarantees that async queries don't exceed their timeout even if the client crashes / or the user flow forgets to explicitly invoke `cancel`.

To ensure robustness of the query timeout handling in face of network problems or even server side bugs this change doesn't only rely on the server side timeouts.
As a safety net there is also local enforcement (which happens with a configurable delay to allow the server to terminate first)

As a related change the driver now also internally tracks timeouts more accurately (both for executeQuery as well as for the custom `wait*` methods).
- The old approach was in some places relying on non monotonic clocks (`Instant`) and thus would have resulted in failures around system clock updates / summer time changes
- The old approach sometimes waited for a multiple of the configured query timeout

To remove this class of issues usages a new Deadline class is introduced that tracks the remaining time for a timeout.