### PR TITLE
feat: Allow toggling of including query details in exception messages

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
@@ -222,7 +222,11 @@ public class DataCloudConnection implements Connection, AutoCloseable {
         log.info("Get row-based result set. queryId={}, offset={}, limit={}, mode={}", queryId, offset, limit, mode);
         val executor = HyperGrpcClientExecutor.forSubmittedQuery(getStub());
         val iterator = RowBased.of(executor, queryId, offset, limit, mode);
-        return StreamingResultSet.of(queryId, executor, iterator);
+        return StreamingResultSet.of(
+                queryId,
+                executor,
+                iterator,
+                connectionProperties.getStatementProperties().isIncludeCustomerDetailInReason());
     }
 
     public DataCloudResultSet getChunkBasedResultSet(String queryId, long chunkId, long limit)
@@ -230,7 +234,11 @@ public class DataCloudConnection implements Connection, AutoCloseable {
         log.info("Get chunk-based result set. queryId={}, chunkId={}, limit={}", queryId, chunkId, limit);
         val executor = HyperGrpcClientExecutor.forSubmittedQuery(getStub());
         val iterator = ChunkBased.of(executor, queryId, chunkId, limit);
-        return StreamingResultSet.of(queryId, executor, iterator);
+        return StreamingResultSet.of(
+                queryId,
+                executor,
+                iterator,
+                connectionProperties.getStatementProperties().isIncludeCustomerDetailInReason());
     }
 
     public DataCloudResultSet getChunkBasedResultSet(String queryId, long chunkId) throws DataCloudJDBCException {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatement.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatement.java
@@ -117,7 +117,8 @@ public class DataCloudPreparedStatement extends DataCloudStatement implements Pr
         val queryTimeout = QueryTimeout.of(
                 statementProperties.getQueryTimeout(), statementProperties.getQueryTimeoutLocalEnforcementDelay());
         val client = getQueryExecutor(queryTimeout);
-        listener = AsyncQueryStatusListener.of(sql, client, queryTimeout);
+        listener = AsyncQueryStatusListener.of(
+                sql, client, queryTimeout, statementProperties.isIncludeCustomerDetailInReason());
         return true;
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
@@ -114,8 +114,15 @@ public class DataCloudStatement implements Statement, AutoCloseable {
                 statementProperties.getQueryTimeout(), statementProperties.getQueryTimeoutLocalEnforcementDelay());
         val client = getQueryExecutor(queryTimeout);
         listener = targetMaxRows > 0
-                ? AdaptiveQueryStatusListener.of(sql, client, queryTimeout, targetMaxRows, targetMaxBytes)
-                : AdaptiveQueryStatusListener.of(sql, client, queryTimeout);
+                ? AdaptiveQueryStatusListener.of(
+                        sql,
+                        client,
+                        queryTimeout,
+                        targetMaxRows,
+                        targetMaxBytes,
+                        statementProperties.isIncludeCustomerDetailInReason())
+                : AdaptiveQueryStatusListener.of(
+                        sql, client, queryTimeout, statementProperties.isIncludeCustomerDetailInReason());
 
         resultSet = listener.generateResultSet();
         log.info("executeAdaptiveQuery completed. queryId={}", listener.getQueryId());
@@ -127,7 +134,8 @@ public class DataCloudStatement implements Statement, AutoCloseable {
         val queryTimeout = QueryTimeout.of(
                 statementProperties.getQueryTimeout(), statementProperties.getQueryTimeoutLocalEnforcementDelay());
         val client = getQueryExecutor(queryTimeout);
-        listener = AsyncQueryStatusListener.of(sql, client, queryTimeout);
+        listener = AsyncQueryStatusListener.of(
+                sql, client, queryTimeout, statementProperties.isIncludeCustomerDetailInReason());
         log.info("executeAsyncQuery completed. queryId={}", listener.getQueryId());
         return this;
     }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StatementProperties.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StatementProperties.java
@@ -53,6 +53,12 @@ public class StatementProperties {
     private final Map<String, String> querySettings = new HashMap<>();
 
     /**
+     * Whether to include query or other fragments that contain details from the query in the reason for the exception.
+     */
+    @Builder.Default
+    private final boolean includeCustomerDetailInReason = true;
+
+    /**
      * Parses statement properties from a Properties object.
      *
      * @param props The properties to parse
@@ -90,6 +96,11 @@ public class StatementProperties {
             }
         }
 
+        String errorsIncludeCustomerDetailsStr = props.getProperty("errorsIncludeCustomerDetails");
+        if (errorsIncludeCustomerDetailsStr != null) {
+            builder.includeCustomerDetailInReason(Boolean.parseBoolean(errorsIncludeCustomerDetailsStr));
+        }
+
         // Parse querySetting.* properties
         Map<String, String> querySettings = new HashMap<>();
         for (String key : props.stringPropertyNames()) {
@@ -120,6 +131,14 @@ public class StatementProperties {
 
         if (!queryTimeout.isZero()) {
             props.setProperty("queryTimeout", String.valueOf(queryTimeout.getSeconds()));
+        }
+        if (!queryTimeoutLocalEnforcementDelay.isZero()) {
+            props.setProperty(
+                    "queryTimeoutLocalEnforcementDelay",
+                    String.valueOf(queryTimeoutLocalEnforcementDelay.getSeconds()));
+        }
+        if (!includeCustomerDetailInReason) {
+            props.setProperty("errorsIncludeCustomerDetails", "false");
         }
         for (Map.Entry<String, String> entry : querySettings.entrySet()) {
             props.setProperty("querySetting." + entry.getKey(), entry.getValue());

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
@@ -67,7 +67,10 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
 
     @SneakyThrows
     public static StreamingResultSet of(
-            String queryId, HyperGrpcClientExecutor client, Iterator<QueryResult> iterator) {
+            String queryId,
+            HyperGrpcClientExecutor client,
+            Iterator<QueryResult> iterator,
+            boolean includeCustomerDetailInReason) {
         try {
             val channel = ExecuteQueryResponseChannel.of(StreamUtilities.toStream(iterator));
             val reader = new ArrowStreamReader(channel, new RootAllocator(ROOT_ALLOCATOR_MB_FROM_V2));
@@ -85,7 +88,7 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
 
             return result;
         } catch (Exception ex) {
-            throw createException(QUERY_FAILURE + queryId, ex);
+            throw createException(null, queryId, includeCustomerDetailInReason, ex);
         }
     }
 
@@ -102,8 +105,6 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
 
         return client.getQueryStatus(queryId);
     }
-
-    private static final String QUERY_FAILURE = "Failed to execute query: ";
 
     @Override
     public int getType() {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCLimitsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCLimitsTest.java
@@ -57,7 +57,7 @@ public class JDBCLimitsTest {
                     })
                     // Also verify that we don't explode exception sizes by keeping the full query
                     .withMessageEndingWith("<truncated>")
-                    .satisfies(t -> assertThat(t.getMessage()).hasSizeLessThan(16500));
+                    .satisfies(t -> assertThat(t.getMessage()).hasSizeLessThan(16600));
         });
     }
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertiesTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertiesTest.java
@@ -101,6 +101,8 @@ class PropertiesTest extends HyperGrpcTestBase {
         properties.setProperty("querySetting.B", "B");
         // Cover setting that internally is represented as non string (`Duration`)
         properties.setProperty("queryTimeout", "30");
+        properties.setProperty("queryTimeoutLocalEnforcementDelay", "10");
+        properties.setProperty("errorsIncludeCustomerDetails", "false");
         ConnectionProperties connectionProperties = ConnectionProperties.of(properties);
         Properties roundtripProperties = connectionProperties.toProperties();
         assertThat(roundtripProperties.entrySet()).containsExactlyInAnyOrderElementsOf(properties.entrySet());

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AdaptiveQueryStatusListenerTest.java
@@ -89,7 +89,8 @@ public class AdaptiveQueryStatusListenerTest extends HyperGrpcTestBase {
 
         val ex = Assertions.assertThrows(
                 DataCloudJDBCException.class,
-                () -> AdaptiveQueryStatusListener.of("any", client, QueryTimeout.of(Duration.ZERO, Duration.ZERO)));
+                () -> AdaptiveQueryStatusListener.of(
+                        "any", client, QueryTimeout.of(Duration.ZERO, Duration.ZERO), true));
         AssertionsForClassTypes.assertThat(ex)
                 .hasMessageContaining("Failed to execute query: ")
                 .hasRootCauseInstanceOf(StatusRuntimeException.class);
@@ -97,6 +98,7 @@ public class AdaptiveQueryStatusListenerTest extends HyperGrpcTestBase {
 
     @SneakyThrows
     QueryStatusListener sut(String query) {
-        return AdaptiveQueryStatusListener.of(query, hyperGrpcClient, QueryTimeout.of(Duration.ZERO, Duration.ZERO));
+        return AdaptiveQueryStatusListener.of(
+                query, hyperGrpcClient, QueryTimeout.of(Duration.ZERO, Duration.ZERO), true);
     }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/AsyncQueryStatusListenerTest.java
@@ -122,6 +122,6 @@ class AsyncQueryStatusListenerTest extends HyperGrpcTestBase {
 
     @SneakyThrows
     QueryStatusListener sut(String query) {
-        return AsyncQueryStatusListener.of(query, hyperGrpcClient, QueryTimeout.of(Duration.ZERO, Duration.ZERO));
+        return AsyncQueryStatusListener.of(query, hyperGrpcClient, QueryTimeout.of(Duration.ZERO, Duration.ZERO), true);
     }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/listener/QueryStatusListenerTest.java
@@ -39,9 +39,11 @@ class QueryStatusListenerTest extends HyperGrpcTestBase {
     private QueryStatusListener sut(String query, QueryParam.TransferMode mode, Duration timeout) {
         switch (mode) {
             case ASYNC:
-                return AsyncQueryStatusListener.of(query, hyperGrpcClient, QueryTimeout.of(timeout, Duration.ZERO));
+                return AsyncQueryStatusListener.of(
+                        query, hyperGrpcClient, QueryTimeout.of(timeout, Duration.ZERO), true);
             case ADAPTIVE:
-                return AdaptiveQueryStatusListener.of(query, hyperGrpcClient, QueryTimeout.of(timeout, Duration.ZERO));
+                return AdaptiveQueryStatusListener.of(
+                        query, hyperGrpcClient, QueryTimeout.of(timeout, Duration.ZERO), true);
             default:
                 Assertions.fail("QueryStatusListener mode not supported. mode=" + mode.name());
                 return null;

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/exception/QueryExceptionHandlerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/exception/QueryExceptionHandlerTest.java
@@ -15,65 +15,140 @@
  */
 package com.salesforce.datacloud.jdbc.exception;
 
+import static com.salesforce.datacloud.jdbc.hyper.HyperTestBase.getHyperQueryConnection;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import com.salesforce.datacloud.jdbc.core.DataCloudStatement;
+import com.salesforce.datacloud.jdbc.hyper.HyperTestBase;
 import com.salesforce.datacloud.jdbc.util.GrpcUtils;
 import io.grpc.StatusRuntimeException;
 import java.sql.SQLException;
+import java.util.Properties;
 import lombok.val;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(HyperTestBase.class)
 class QueryExceptionHandlerTest {
+    @Test
+    public void testServerReportedErrorWithCustomerDetails() throws SQLException {
+        // Verify that the normal exception messages contains the query and customer details & hints from the server
+        // error info
+        try (val connection = getHyperQueryConnection()) {
+            try (val stmt = (DataCloudStatement) connection.createStatement()) {
+                String query = "WITH \"A\" AS (SELECT 1) SELECT * FROM A";
+                DataCloudJDBCException ex = assertThrows(DataCloudJDBCException.class, () -> stmt.executeQuery(query));
+                String customerDetail = "\n"
+                        // Indentation to more easily see that the ascii art matches (the mismatch is from the escape
+                        // characters for the double quotes)
+                        + "line 1, column 38: WITH \"A\" AS (SELECT 1) SELECT * FROM A\n"
+                        + "                                                        ^";
+                String customerHint = "Try quoting the identifier: `\"A\"`";
+                String expectedMessage = "Failed to execute query: table \"a\" does not exist\n" + "SQLSTATE: 42P01\n"
+                        + "QUERY-ID: "
+                        + stmt.getQueryId() + "\n" + "DETAIL: "
+                        + customerDetail
+                        + "\n" + "HINT: "
+                        + customerHint;
+                assertEquals(expectedMessage, ex.getMessage());
+                assertEquals(ex.getMessage(), ex.getFullCustomerMessage());
+                assertEquals("42P01", ex.getSQLState());
+                assertEquals("table \"a\" does not exist", ex.getPrimaryMessage());
+                assertEquals(customerDetail, ex.getCustomerDetail());
+                assertEquals(customerHint, ex.getCustomerHint());
+            }
+        }
+    }
 
     @Test
-    public void testCreateExceptionWithStatusRuntimeException() {
-        StatusRuntimeException fakeException = GrpcUtils.getFakeStatusRuntimeExceptionAsInvalidArgument();
-        SQLException actualException = QueryExceptionHandler.createException("test message", fakeException);
+    public void testServerReportedErrorWithoutCustomerDetails() throws SQLException {
+        // Verify that the normal exception messages does not contain the query or customer details & hints from the
+        // server error info
+        // Also verify that the full customer message does still contain all the information for explicit forwarding.
+        Properties properties = new Properties();
+        properties.setProperty("errorsIncludeCustomerDetails", "false");
+        try (val connection = getHyperQueryConnection(properties)) {
+            try (val stmt = (DataCloudStatement) connection.createStatement()) {
+                String query = "WITH \"A\" AS (SELECT 1) SELECT * FROM A";
+                DataCloudJDBCException ex = assertThrows(DataCloudJDBCException.class, () -> stmt.executeQuery(query));
+                String customerDetail = "\n"
+                        // Indentation to more easily see that the ascii art matches (the mismatch is from the escape
+                        // characters for the double quotes)
+                        + "line 1, column 38: WITH \"A\" AS (SELECT 1) SELECT * FROM A\n"
+                        + "                                                        ^";
+                String customerHint = "Try quoting the identifier: `\"A\"`";
+                String expectedMessage = "Failed to execute query: table \"a\" does not exist\n"
+                        + "SQLSTATE: 42P01\n"
+                        + "QUERY-ID: "
+                        + stmt.getQueryId();
+                String expectedFullCustomerMessage =
+                        "Failed to execute query: table \"a\" does not exist\n" + "SQLSTATE: 42P01\n"
+                                + "QUERY-ID: "
+                                + stmt.getQueryId() + "\n" + "DETAIL: "
+                                + customerDetail
+                                + "\n" + "HINT: "
+                                + customerHint;
+                assertEquals(expectedMessage, ex.getMessage());
+                assertEquals(expectedFullCustomerMessage, ex.getFullCustomerMessage());
+                assertEquals("42P01", ex.getSQLState());
+                assertEquals("table \"a\" does not exist", ex.getPrimaryMessage());
+                assertEquals(customerDetail, ex.getCustomerDetail());
+                assertEquals(customerHint, ex.getCustomerHint());
+            }
+        }
+    }
 
+    @Test
+    public void testCreateExceptionWithStatusRuntimeExceptionAndCustomerDetails() {
+        StatusRuntimeException fakeException = GrpcUtils.getFakeStatusRuntimeExceptionAsInvalidArgument();
+        String fullMessage = "Failed to execute query: Resource Not Found\n" + "SQLSTATE: 42P01\n"
+                + "QUERY-ID: 1-2-3-4\n"
+                + "QUERY: SELECT 1";
+        String redactedMessage =
+                "Failed to execute query: Resource Not Found\n" + "SQLSTATE: 42P01\n" + "QUERY-ID: 1-2-3-4";
+
+        // Verify with customer details
+        DataCloudJDBCException actualException =
+                QueryExceptionHandler.createException("SELECT 1", "1-2-3-4", true, fakeException);
         assertInstanceOf(SQLException.class, actualException);
         assertEquals("42P01", actualException.getSQLState());
-        val sep = System.lineSeparator();
-        assertEquals(
-                "42P01: Table not found" + sep + "DETAIL:" + sep + sep + "HINT:" + sep, actualException.getMessage());
+        assertEquals(fullMessage, actualException.getMessage());
+        assertEquals(fullMessage, actualException.getFullCustomerMessage());
+        assertEquals(StatusRuntimeException.class, actualException.getCause().getClass());
+
+        // Verify without customer details
+        actualException = QueryExceptionHandler.createException("SELECT 1", "1-2-3-4", false, fakeException);
+        assertEquals(redactedMessage, actualException.getMessage());
+        assertEquals(fullMessage, actualException.getFullCustomerMessage());
         assertEquals(StatusRuntimeException.class, actualException.getCause().getClass());
     }
 
     @Test
     void testCreateExceptionWithGenericException() {
-        Exception mockException = new Exception("Generic exception");
-        SQLException sqlException = QueryExceptionHandler.createException("Default message", mockException);
+        Exception mockException = new Exception("Host not found");
+        String fullMessage = "Failed to execute query: Host not found\n" + "SQLSTATE: HY000\n"
+                + "QUERY-ID: 1-2-3-4\n"
+                + "QUERY: SELECT 1";
+        String redactedMessage =
+                "Failed to execute query: Host not found\n" + "SQLSTATE: HY000\n" + "QUERY-ID: 1-2-3-4";
 
-        assertEquals("Default message", sqlException.getMessage());
+        // Test with customer details
+        DataCloudJDBCException sqlException =
+                QueryExceptionHandler.createException("SELECT 1", "1-2-3-4", true, mockException);
+        assertEquals(fullMessage, sqlException.getMessage());
+        assertEquals(sqlException.getMessage(), sqlException.getFullCustomerMessage());
+        assertEquals("HY000", sqlException.getSQLState());
+        assertEquals("Host not found", sqlException.getCause().getMessage());
         assertEquals(mockException, sqlException.getCause());
-    }
 
-    @Test
-    void testCreateException() {
-        SQLException actualException = QueryExceptionHandler.createException("test message");
-
-        assertInstanceOf(SQLException.class, actualException);
-        assertEquals("test message", actualException.getMessage());
-    }
-
-    @Test
-    public void testCreateExceptionWithSQLStateAndThrowableCause() {
-        Exception mockException = new Exception("Generic exception");
-        String mockSQLState = "42P01";
-        SQLException sqlException = QueryExceptionHandler.createException("test message", mockSQLState, mockException);
-
-        assertInstanceOf(SQLException.class, sqlException);
-        assertEquals("42P01", sqlException.getSQLState());
-        assertEquals("test message", sqlException.getMessage());
-    }
-
-    @Test
-    public void testCreateExceptionWithSQLStateAndMessage() {
-        String mockSQLState = "42P01";
-        SQLException sqlException = QueryExceptionHandler.createException("test message", mockSQLState);
-
-        assertInstanceOf(SQLException.class, sqlException);
-        assertEquals("42P01", sqlException.getSQLState());
-        assertEquals("test message", sqlException.getMessage());
+        // Test without customer details
+        sqlException = QueryExceptionHandler.createException("SELECT 1", "1-2-3-4", false, mockException);
+        assertEquals(redactedMessage, sqlException.getMessage());
+        assertEquals(fullMessage, sqlException.getFullCustomerMessage());
+        assertEquals("HY000", sqlException.getSQLState());
+        assertEquals("Host not found", sqlException.getCause().getMessage());
+        assertEquals(mockException, sqlException.getCause());
     }
 }

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/exception/DataCloudJDBCException.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/exception/DataCloudJDBCException.java
@@ -20,13 +20,13 @@ import lombok.Getter;
 
 @Getter
 public class DataCloudJDBCException extends SQLException {
+    private String fullCustomerMessage;
+
+    private String primaryMessage;
+
     private String customerHint;
 
     private String customerDetail;
-
-    public DataCloudJDBCException() {
-        super();
-    }
 
     public DataCloudJDBCException(String reason) {
         super(reason);
@@ -34,10 +34,6 @@ public class DataCloudJDBCException extends SQLException {
 
     public DataCloudJDBCException(String reason, String SQLState) {
         super(reason, SQLState);
-    }
-
-    public DataCloudJDBCException(String reason, String SQLState, int vendorCode) {
-        super(reason, SQLState, vendorCode);
     }
 
     public DataCloudJDBCException(Throwable cause) {
@@ -52,14 +48,23 @@ public class DataCloudJDBCException extends SQLException {
         super(reason, SQLState, cause);
     }
 
-    public DataCloudJDBCException(String reason, String SQLState, int vendorCode, Throwable cause) {
-        super(reason, SQLState, vendorCode, cause);
+    public DataCloudJDBCException(String reason, String fullCustomerMessage, String SQLState, Throwable cause) {
+        super(reason, SQLState, cause);
+        this.fullCustomerMessage = fullCustomerMessage;
     }
 
     public DataCloudJDBCException(
-            String reason, String SQLState, String customerHint, String customerDetail, Throwable cause) {
-        super(reason, SQLState, 0, cause);
+            String reason,
+            String fullCustomerMessage,
+            String SQLState,
+            String primaryMessage,
+            String customerHint,
+            String customerDetail,
+            Throwable cause) {
+        super(reason, SQLState, cause);
 
+        this.fullCustomerMessage = fullCustomerMessage;
+        this.primaryMessage = primaryMessage;
         this.customerHint = customerHint;
         this.customerDetail = customerDetail;
     }


### PR DESCRIPTION
For some use cases like logging in an app server it can be undesirable to log query / snippets as they might contain data that should not be logged. This change adds new property `errorsIncludeCustomerDetails` that allows removing such information from the generic exception message. The default is kept like before to still show it.
Independent of the mode the full information is preserved in the exception and can be access using `getFullCustomerMessage()`.

As the change needs to no support having the query included / excluded from the message the format was adjusted to ensure such an inclusion/exclusion doesn't impact the readability of the message (same also for query id, which might be available in some context and missing in others). The new general error formatting is
```
Failed to execute query: <server side message / local exception message>
SQLSTATE: <server provided / "HY==" for generic error>
QUERY-ID: ... <-- Line only if available
DETAIL: ... <-- Line only if available
HINT:... <-- Line only if available
QUERY: ... <-- Line only if available
```

With this change the signature for exception creation was adjusted to explicitly required always passing `query-id` and `query`. There were many places where the query id could have been passed but wasn't and same for the query. (Not all places were fixed in this PR because that would require larger refactorings).

Drive-By:
- Remove unused signatures and their test coverage
- Fix missing serialization of `queryTimeoutLocalEnforcementDelay` property

Future work:
- The new interface uncovered several places on the execute query flow where the query is not available for formatting the exception. Those places should be adjusted so that they get access to the query string
- The error info contains additional information that is not yet part of the exception. We should revisit our exception to add this information as well.
- Our `DataCloudJDBCException` has many overloads that just forward to the generic SQLException. Those could get removed and those places could just throw an SQLException