### PR TITLE
feat: add getQueryInfo retry mechanism for usage in FSMs

### DIFF
--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcTestBase.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcTestBase.java
@@ -16,6 +16,7 @@
 package com.salesforce.datacloud.jdbc.core;
 
 import com.salesforce.datacloud.jdbc.hyper.HyperServerConfig;
+import com.salesforce.datacloud.jdbc.hyper.HyperServerManager;
 import com.salesforce.datacloud.jdbc.hyper.HyperServerProcess;
 import com.salesforce.datacloud.jdbc.interceptor.QueryIdHeaderInterceptor;
 import com.salesforce.datacloud.jdbc.util.RealisticArrowGenerator;
@@ -90,16 +91,14 @@ public class HyperGrpcTestBase {
         });
     }
 
-    protected DataCloudConnection getInterceptedClientConnection() {
-        return getInterceptedClientConnection(HyperServerConfig.builder().build());
+    protected DataCloudConnection getInterceptedClientConnection(
+            HyperServerConfig config, HyperServerManager.ConfigFile configFile) {
+        val server = HyperServerManager.get(config.toBuilder(), configFile);
+        return getInterceptedClientConnection(server);
     }
 
     @SneakyThrows
-    protected DataCloudConnection getInterceptedClientConnection(HyperServerConfig config) {
-
-        val server = config.start();
-        servers.add(server);
-
+    protected DataCloudConnection getInterceptedClientConnection(HyperServerProcess server) {
         val channel = ManagedChannelBuilder.forAddress("127.0.0.1", server.getPort())
                 .usePlaintext()
                 .maxInboundMessageSize(64 * 1024 * 1024)
@@ -130,6 +129,19 @@ public class HyperGrpcTestBase {
         val conn = DataCloudConnection.of(mocked, new Properties());
         connections.add(conn);
         return conn;
+    }
+
+    protected DataCloudConnection getInterceptedClientConnection() {
+        return getInterceptedClientConnection(
+                HyperServerConfig.builder().build(), HyperServerManager.ConfigFile.SMALL_CHUNKS);
+    }
+
+    @SneakyThrows
+    protected DataCloudConnection getInterceptedClientConnection(HyperServerConfig config) {
+        val server = config.start();
+        servers.add(server);
+
+        return getInterceptedClientConnection(server);
     }
 
     public static <ReqT, RespT> void proxyStreamingMethod(

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/fsm/AdaptiveQueryResultIteratorFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/fsm/AdaptiveQueryResultIteratorFunctionalTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.datacloud.jdbc.core.fsm;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.grpcmock.GrpcMock.*;
+import static org.grpcmock.GrpcMock.atLeast;
+import static org.grpcmock.GrpcMock.calledMethod;
+import static org.grpcmock.GrpcMock.verifyThat;
+
+import com.salesforce.datacloud.jdbc.core.DataCloudPreparedStatement;
+import com.salesforce.datacloud.jdbc.core.HyperGrpcTestBase;
+import com.salesforce.datacloud.jdbc.hyper.HyperServerConfig;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import salesforce.cdp.hyperdb.v1.HyperServiceGrpc;
+
+public class AdaptiveQueryResultIteratorFunctionalTest extends HyperGrpcTestBase {
+    @SneakyThrows
+    @Test
+    @Disabled("Disabled until we can tune grpc-request-timeout and pg_sleep to reliably cause a query info CANCELLED")
+    void getQueryInfoRetriesOnTimeout() {
+        val size = 10000;
+        val results = new ArrayList<Integer>();
+        val configWithSleep =
+                HyperServerConfig.builder().grpcRequestTimeoutSeconds("4s").build();
+
+        try (val conn = getInterceptedClientConnection(configWithSleep)) {
+            val stmt = conn.prepareStatement("SELECT g FROM generate_series(1,?) g WHERE pg_sleep(8)")
+                    .unwrap(DataCloudPreparedStatement.class);
+            stmt.setInt(1, size);
+            val rs = stmt.executeQuery();
+
+            verifyThat(calledMethod(HyperServiceGrpc.getGetQueryInfoMethod()), times(0));
+
+            while (rs.next()) {
+                results.add(rs.getInt(1));
+            }
+
+            assertThat(results)
+                    .containsExactlyInAnyOrderElementsOf(
+                            IntStream.rangeClosed(1, size).boxed().collect(Collectors.toList()));
+
+            verifyThat(calledMethod(HyperServiceGrpc.getGetQueryInfoMethod()), atLeast(2));
+        }
+    }
+}

--- a/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerManager.java
+++ b/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerManager.java
@@ -1,5 +1,6 @@
 package com.salesforce.datacloud.jdbc.hyper;
 
+import lombok.AllArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -10,6 +11,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 public final class HyperServerManager {
+    @AllArgsConstructor
+    public enum ConfigFile {
+        DEFAULT("default.yaml"),
+        SMALL_CHUNKS("hyper.yaml"),
+        TIMEOUT("timeout.yaml");
+
+        final String filename;
+    }
+
     private static final Map<HyperProcessHandle, HyperServerProcess> instances = new ConcurrentHashMap<>();
 
     private static final AtomicBoolean installed = new AtomicBoolean(false);
@@ -51,12 +61,18 @@ public final class HyperServerManager {
         });
     }
 
+    public static HyperServerProcess get(HyperServerConfig.HyperServerConfigBuilder builder, ConfigFile yaml) {
+        return get(builder, yaml.filename);
+    }
+
+    @Deprecated
     public static HyperServerProcess closeToDefault() {
         val config = HyperServerConfig.builder();
         val name = "default.yaml";
         return get(config, name);
     }
 
+    @Deprecated
     public static HyperServerProcess withSmallChunks() {
         val config = HyperServerConfig.builder();
         val name = "hyper.yaml";


### PR DESCRIPTION
This pull request improves the resilience and correctness of the `AdaptiveQueryResultIterator` by handling gRPC `CANCELLED` exceptions during query streaming, ensuring retry logic is properly implemented and tested -- the "finite state machine" will never give up due to a `CANCELLED` status code.
