### PR TITLE
Fix: Resolve gRPC hostname parsing issue in OAuth connections

### DIFF
--- a/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
+++ b/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
@@ -146,7 +146,26 @@ public class DataCloudJDBCDriver implements Driver {
         val tokenProcessor = getDataCloudTokenProcessor(properties);
         val authInterceptor = TokenProcessorSupplier.of(tokenProcessor);
 
-        val host = tokenProcessor.getDataCloudToken().getTenantUrl();
+                val tenantUrl = tokenProcessor.getDataCloudToken().getTenantUrl();
+        log.info("Creating gRPC channel for tenant URL: {}", tenantUrl);
+        
+        // Extract hostname from tenant URL, handling both URLs with and without schemes
+        String host;
+        if (tenantUrl.contains("://")) {
+            // URL has a scheme, parse it normally
+            val tenantUri = java.net.URI.create(tenantUrl);
+            host = tenantUri.getHost();
+        } else {
+            // URL is just a hostname, use it directly
+            host = tenantUrl;
+        }
+        log.info("Extracted hostname from tenant URL: {}", host);
+        
+        if (host == null || host.trim().isEmpty()) {
+            throw new DataCloudJDBCException(
+                String.format("Invalid tenant URL '%s': could not extract hostname", tenantUrl));
+        }
+        
         final ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(
                         host, DataCloudConnection.DEFAULT_PORT)
                 .intercept(TracingHeadersInterceptor.of());


### PR DESCRIPTION
Addressing an issue that clients have with non-browser OAuth flows.

Fix NullPointerException when tenant URL lacks scheme. Handle both URLs with schemes (`https://hostname.com`) and without (`hostname.com`). Add validation to ensure hostname is not null or empty before gRPC channel creation. Add logging to help debug tenant URL parsing issues.