### PR TITLE
ci: add aggregated jacoco coverage and build script formatting

### DIFF
--- a/.github/workflows/reusable-build-publish.yml
+++ b/.github/workflows/reusable-build-publish.yml
@@ -61,6 +61,9 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -99,6 +102,25 @@ jobs:
           gradle clean build --no-build-cache --rerun-tasks
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+      - name: Generate coverage report
+        run: gradle testCodeCoverageReport
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+      - name: Generate JaCoCo Badge (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: cicirello/jacoco-badge-generator@v2
+        with:
+          jacoco-csv-file: build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.csv
+          badges-directory: .github/badges
+          generate-coverage-badge: true
+          generate-branches-badge: true
+          generate-summary: true
+          generate-coverage-endpoint: true
+          generate-branches-endpoint: true
+          fail-if-coverage-less-than: 60
+          fail-on-coverage-decrease: true
+          coverage-decrease-limit: 5
+          generate-workflow-summary: true
       - name: Look at files in verification
         if: ${{ failure() }}
         uses: jaywcjlove/github-action-folder-tree@main

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,27 +4,24 @@ plugins {
     id("version-conventions")
     id("com.diffplug.spotless")
     id("dev.iurysouza.modulegraph") version "0.12.0"
+    id("jacoco-report-aggregation")
 }
+
+repositories { mavenCentral() }
 
 tasks.register("printVersion") {
     val projectVersion = version.toString()
-    doLast {
-        println(projectVersion)
-    }
+    doLast { println(projectVersion) }
 }
 
 tasks.register("printHyperApiVersion") {
     val hyperVersion = project.findProperty("hyperApiVersion")?.toString() ?: "unknown"
-    doLast {
-        println(hyperVersion)
-    }
+    doLast { println(hyperVersion) }
 }
 
 subprojects {
     plugins.withId("java-conventions") {
-        tasks.withType<Test>().configureEach {
-            dependsOn(rootProject.tasks.named("extractHyper"))
-        }
+        tasks.withType<Test>().configureEach { dependsOn(rootProject.tasks.named("extractHyper")) }
     }
 }
 
@@ -33,3 +30,53 @@ moduleGraphConfig {
     heading.set("## Module Graph")
     rootModulesRegex.set("^:jdbc|:spark-datasource$")
 }
+
+spotless {
+    kotlinGradle {
+        target("*.gradle.kts", "buildSrc/*.gradle.kts", "buildSrc/src/**/*.gradle.kts")
+        targetExclude("**/build/**")
+        ktfmt().googleStyle().configure {
+            it.setBlockIndent(4)
+            it.setMaxWidth(120)
+            it.setContinuationIndent(4)
+            it.setManageTrailingCommas(true)
+            it.setRemoveUnusedImports(true)
+        }
+    }
+}
+
+dependencies {
+    jacocoAggregation(project(":jdbc"))
+    jacocoAggregation(project(":jdbc-core"))
+    jacocoAggregation(project(":jdbc-grpc"))
+    jacocoAggregation(project(":jdbc-http"))
+    jacocoAggregation(project(":jdbc-util"))
+    jacocoAggregation(project(":jdbc-reference"))
+    jacocoAggregation(project(":spark-datasource"))
+}
+
+reporting {
+    reports {
+        val testCodeCoverageReport by
+            creating(JacocoCoverageReport::class) {
+                testSuiteName.set("test")
+                reportTask
+                    .get()
+                    .classDirectories
+                    .setFrom(
+                        reportTask.get().classDirectories.map {
+                            fileTree(it).matching {
+                                exclude("salesforce/cdp/hyperdb/v1/**", "com/salesforce/datacloud/reference/**")
+                            }
+                        }
+                    )
+                reportTask.get().reports.apply {
+                    xml.required.set(true)
+                    csv.required.set(true)
+                }
+            }
+
+    }
+}
+
+tasks.named("build") { dependsOn(tasks.named("testCodeCoverageReport")) }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,16 +1,11 @@
-plugins {
-    `kotlin-dsl`
-}
+plugins { `kotlin-dsl` }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 dependencies {
     implementation("com.google.osdetector:com.google.osdetector.gradle.plugin:1.7.3")
     implementation("de.undercouch.download:de.undercouch.download.gradle.plugin:5.6.0")
     implementation("dev.adamko.dev-publish:dev.adamko.dev-publish.gradle.plugin:0.4.2")
     implementation("com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:7.0.2")
+    implementation("com.facebook:ktfmt:0.44")
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,22 +1,18 @@
 rootProject.name = "buildSrc"
 
 pluginManagement {
-   repositories {
-      mavenCentral()
-      gradlePluginPortal()
-   }
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-   repositoriesMode = RepositoriesMode.PREFER_SETTINGS
-   repositories {
-      mavenCentral()
-      gradlePluginPortal()
-   }
-   versionCatalogs {
-      create("libs") {
-         from(files("../gradle/libs.versions.toml"))
-      }
-   }
+    repositoriesMode = RepositoriesMode.PREFER_SETTINGS
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
 }

--- a/buildSrc/src/main/kotlin/base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/base-conventions.gradle.kts
@@ -10,8 +10,6 @@ tasks.withType<AbstractArchiveTask>().configureEach {
 }
 
 spotless {
-//    ratchetFrom("origin/main")
-
     format("misc") {
         target(".gitattributes", ".gitignore")
         trimTrailingWhitespace()

--- a/buildSrc/src/main/kotlin/hyper-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/hyper-conventions.gradle.kts
@@ -12,16 +12,18 @@ tasks.register<de.undercouch.gradle.tasks.download.Download>("downloadHyper") {
 
     val os = "os=${osdetector.os}, arch=${osdetector.arch}, classifier=${osdetector.classifier}"
 
-    val osPart = when (osdetector.os) {
-        "windows" -> "windows-x86_64-release-main"
-        "linux" -> "linux-x86_64-release-main"
-        "osx" -> when (osdetector.arch) {
-            "aarch_64" -> "macos-arm64-release-main"
-            else -> "macos-x86_64-release-main"
-        }
+    val osPart =
+        when (osdetector.os) {
+            "windows" -> "windows-x86_64-release-main"
+            "linux" -> "linux-x86_64-release-main"
+            "osx" ->
+                when (osdetector.arch) {
+                    "aarch_64" -> "macos-arm64-release-main"
+                    else -> "macos-x86_64-release-main"
+                }
 
-        else -> throw GradleException("Unsupported os settings. $os")
-    }
+            else -> throw GradleException("Unsupported os settings. $os")
+        }
 
     val url = "https://downloads.tableau.com/tssoftware/tableauhyperapi-cxx-$osPart.$hyperApiVersion.zip"
     val zip = project.layout.projectDirectory.file(hyperZipPath)
@@ -58,13 +60,9 @@ tasks.register<Copy>("extractHyper") {
 
     into(project.layout.projectDirectory.dir(hyperDir))
 
-    eachFile {
-        relativePath = RelativePath(true, name)
-    }
+    eachFile { relativePath = RelativePath(true, name) }
 
-    filePermissions {
-        unix("rwx------")
-    }
+    filePermissions { unix("rwx------") }
 
     val hyperdDir = project.layout.projectDirectory.dir(hyperDir).asFileTree
 
@@ -72,12 +70,15 @@ tasks.register<Copy>("extractHyper") {
     outputs.files(hyperdDir.files)
 
     doLast {
+        val exe =
+            hyperdDir.firstOrNull { it.name.contains("hyperd") }
+                ?: throw GradleException(
+                    "zip missing hyperd executable. $os, files=${hyperdDir.map { it.absolutePath }}"
+                )
 
-        val exe = hyperdDir.firstOrNull { it.name.contains("hyperd") }
-            ?: throw GradleException("zip missing hyperd executable. $os, files=${hyperdDir.map { it.absolutePath }}")
-
-        val lib = hyperdDir.firstOrNull { it.name.contains("tableauhyperapi") }
-            ?: throw GradleException("zip missing hyperd library, $os, files=${hyperdDir.map { it.absolutePath }}")
+        val lib =
+            hyperdDir.firstOrNull { it.name.contains("tableauhyperapi") }
+                ?: throw GradleException("zip missing hyperd library, $os, files=${hyperdDir.map { it.absolutePath }}")
 
         if (!exe.exists() || !lib.exists()) {
             throw GradleException("extractHyper failed validation. hyperd=${exe.exists()}, lib=${lib.exists()}, $os")
@@ -89,10 +90,11 @@ tasks.register<Exec>("hyperd") {
     dependsOn("extractHyper")
     group = "hyper"
 
-    val name = when (osdetector.os) {
-        "windows" -> "hyperd.exe"
-        else -> "hyperd"
-    }
+    val name =
+        when (osdetector.os) {
+            "windows" -> "hyperd.exe"
+            else -> "hyperd"
+        }
 
     val executable = project.layout.projectDirectory.dir(hyperDir).file(name).asFile.absolutePath
     val config = project.project(":jdbc-core").file("src/test/resources/hyper.yaml")

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -11,9 +11,7 @@ java {
 }
 
 tasks.withType<JavaCompile> {
-    javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
+    javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(8) }
     options.encoding = "UTF-8"
     options.setIncremental(true)
     // This only works if we're on a newer toolchain, but java 8 is faster to build while we use lombok for "val"

--- a/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
@@ -44,7 +44,6 @@ fun MavenPublication.configurePom(nameProvider: Provider<String>, descProvider: 
     }
 }
 
-
 publishing {
     publications {
         val nameProvider = provider { mavenName }

--- a/buildSrc/src/main/kotlin/scala-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scala-conventions.gradle.kts
@@ -7,13 +7,7 @@ plugins {
 }
 
 tasks.withType<ScalaCompile> {
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
+    javaLauncher = javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(8) }
 }
 
-spotless {    
-    scala {
-        scalafmt()
-    }
-}
+spotless { scala { scalafmt() } }

--- a/buildSrc/src/main/kotlin/version-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/version-conventions.gradle.kts
@@ -1,19 +1,22 @@
-
 val revision: String by project
 
-private val ci = object {
-    private val snapshotVersion = when (System.getenv("GITHUB_RUN_NUMBER")) {
-        null -> "$revision-LOCAL"
-        else -> "$revision-SNAPSHOT"
-    }
+private val ci =
+    object {
+        private val snapshotVersion =
+            when (System.getenv("GITHUB_RUN_NUMBER")) {
+                null -> "$revision-LOCAL"
+                else -> "$revision-SNAPSHOT"
+            }
 
-    private val releaseVersion = System.getenv("RELEASE_VERSION")?.ifBlank {
-        logger.lifecycle("env.RELEASE_VERSION not present, assuming snapshot")
-        null
-    }
+        private val releaseVersion =
+            System.getenv("RELEASE_VERSION")?.ifBlank {
+                logger.lifecycle("env.RELEASE_VERSION not present, assuming snapshot")
+                null
+            }
 
-    val resolvedVersion = releaseVersion ?: snapshotVersion
-}
+        val resolvedVersion = releaseVersion ?: snapshotVersion
+    }
 
 group = "com.salesforce.datacloud"
+
 version = ci.resolvedVersion

--- a/jdbc-core/build.gradle.kts
+++ b/jdbc-core/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "Salesforce Data Cloud JDBC core implementation"
+
 val mavenName: String by extra("Salesforce Data Cloud JDBC Core")
 val mavenDescription: String by extra("${project.description}")
 
@@ -41,6 +42,4 @@ dependencies {
     testImplementation(libs.bundles.grpc.testing)
 }
 
-tasks.named("compileJava") {
-    dependsOn(":jdbc-grpc:compileJava")
-}
+tasks.named("compileJava") { dependsOn(":jdbc-grpc:compileJava") }

--- a/jdbc-grpc/build.gradle.kts
+++ b/jdbc-grpc/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 }
 
 description = "Salesforce Data Cloud Query v3 API gRPC stubs"
+
 val mavenName: String by extra("Salesforce Data Cloud JDBC gRPC")
 val mavenDescription: String by extra("${project.description}")
 
@@ -17,43 +18,30 @@ dependencies {
 }
 
 // Based on: https://github.com/google/protobuf-gradle-plugin/blob/master/examples/exampleKotlinDslProject
-sourceSets {
-    main {
-        proto {
-            srcDir(project(":jdbc-proto").projectDir.resolve("src/main/proto"))
-        }
-    }
-}
+sourceSets { main { proto { srcDir(project(":jdbc-proto").projectDir.resolve("src/main/proto")) } } }
 
 protobuf {
-    protoc {
-        artifact = libs.protoc.get().toString()
-    }
-    plugins {
-        create("grpc") {
-            artifact = libs.grpc.protoc.get().toString()
-        }
-    }
+    protoc { artifact = libs.protoc.get().toString() }
+    plugins { create("grpc") { artifact = libs.grpc.protoc.get().toString() } }
     generateProtoTasks {
         ofSourceSet("main").forEach {
-            it.plugins {
-                id("grpc") { }
-            }
+            it.plugins { id("grpc") {} }
             it.generateDescriptorSet = true
         }
     }
 }
 
-tasks.withType<JavaCompile> {
-    dependsOn("generateProto")
-}
+tasks.withType<JavaCompile> { dependsOn("generateProto") }
 
 tasks.jar {
     archiveBaseName.set("jdbc-grpc")
-    val tasks = sourceSets.map { sourceSet ->
-        from(sourceSet.output)
-        sourceSet.getCompileTaskName("java")
-    }.toTypedArray()
+    val tasks =
+        sourceSets
+            .map { sourceSet ->
+                from(sourceSet.output)
+                sourceSet.getCompileTaskName("java")
+            }
+            .toTypedArray()
 
     dependsOn(*tasks)
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/jdbc-http/build.gradle.kts
+++ b/jdbc-http/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
     alias(libs.plugins.lombok)
 }
 
-description = "HTTP utilities including Auth implementations for establishing a connection and SOQL for fetching metadata for Salesforce Data Cloud JDBC driver"
+description =
+    "HTTP utilities including Auth implementations for establishing a connection and SOQL for fetching metadata for Salesforce Data Cloud JDBC driver"
+
 val mavenName: String by extra("Salesforce Data Cloud JDBC HTTP")
 val mavenDescription: String by extra("${project.description}")
 

--- a/jdbc-proto/build.gradle.kts
+++ b/jdbc-proto/build.gradle.kts
@@ -5,27 +5,31 @@ plugins {
 }
 
 description = "Salesforce Data Cloud Query v3 API Protocol Buffer Definitions"
+
 val mavenName: String by extra("Salesforce Data Cloud JDBC Proto")
 val mavenDescription: String by extra("${project.description}")
 
-val protoJar by tasks.registering(Jar::class) {
-    group = LifecycleBasePlugin.BUILD_GROUP
-    archiveBaseName.set("jdbc-proto")
-    from(project.projectDir.resolve("src/main/proto"))
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
+val protoJar by
+    tasks.registering(Jar::class) {
+        group = LifecycleBasePlugin.BUILD_GROUP
+        archiveBaseName.set("jdbc-proto")
+        from(project.projectDir.resolve("src/main/proto"))
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
 
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    archiveBaseName.set("jdbc-proto")
-    from(project.projectDir.resolve("src/main/proto"))
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
+val sourcesJar by
+    tasks.registering(Jar::class) {
+        archiveClassifier.set("sources")
+        archiveBaseName.set("jdbc-proto")
+        from(project.projectDir.resolve("src/main/proto"))
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
 
-val emptyJavadocJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("javadoc")
-    archiveBaseName.set("jdbc-proto")
-}
+val emptyJavadocJar by
+    tasks.registering(Jar::class) {
+        archiveClassifier.set("javadoc")
+        archiveBaseName.set("jdbc-proto")
+    }
 
 artifacts {
     archives(protoJar)

--- a/jdbc-reference/build.gradle.kts
+++ b/jdbc-reference/build.gradle.kts
@@ -16,6 +16,4 @@ dependencies {
     testImplementation(libs.bundles.mocking)
 }
 
-application {
-    mainClass = "com.salesforce.datacloud.reference.PostgresReferenceGenerator"
-}
+application { mainClass = "com.salesforce.datacloud.reference.PostgresReferenceGenerator" }

--- a/jdbc-util/build.gradle.kts
+++ b/jdbc-util/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 description = "Utilities for Java's Stream, Properties, String, etc. for Salesforce Data Cloud JDBC driver"
+
 val mavenName: String by extra("Salesforce Data Cloud JDBC Utilities")
 val mavenDescription: String by extra("${project.description}")
 
@@ -30,6 +31,4 @@ tasks.register("generateVersionProperties") {
     }
 }
 
-tasks.named("compileJava") {
-    dependsOn("generateVersionProperties")
-}
+tasks.named("compileJava") { dependsOn("generateVersionProperties") }

--- a/jdbc/build.gradle.kts
+++ b/jdbc/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "Salesforce Data Cloud JDBC driver"
+
 val mavenName: String by extra("Salesforce Data Cloud JDBC Driver")
 val mavenDescription: String by extra("${project.description}")
 
@@ -26,7 +27,7 @@ dependencies {
 // Common shading configuration to be reused
 fun com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.configureShading() {
     val shadeBase = "com.salesforce.datacloud.shaded"
-    
+
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     relocate("com.google", "$shadeBase.com.google")
@@ -45,10 +46,8 @@ fun com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.configureShading(
     relocate("org.apache.commons", "$shadeBase.org.apache.commons")
     relocate("org.apache.hc", "$shadeBase.org.apache.hc")
 
-    mergeServiceFiles {
-        exclude("META-INF/services/java.sql.Driver")
-    }
-    
+    mergeServiceFiles { exclude("META-INF/services/java.sql.Driver") }
+
     exclude("org.slf4j")
 
     exclude("org.apache.calcite.avatica.remote.Driver")
@@ -80,23 +79,21 @@ tasks.shadowJar {
 }
 
 // Create an additional shadowJar with "shaded" classifier
-val shadedJar = tasks.register<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadedJar") {
-    from(sourceSets.main.get().output)
-    configurations = listOf(project.configurations.runtimeClasspath.get())
-    archiveBaseName = "jdbc"
-    archiveClassifier = "shaded"
-    configureShading()
-    shouldRunAfter(tasks.jar)
-}
+val shadedJar =
+    tasks.register<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadedJar") {
+        from(sourceSets.main.get().output)
+        configurations = listOf(project.configurations.runtimeClasspath.get())
+        archiveBaseName = "jdbc"
+        archiveClassifier = "shaded"
+        configureShading()
+        shouldRunAfter(tasks.jar)
+    }
 
-// This is the base JAR with an "original" classifier, it's not shaded and should become the default JAR after making DBeaver use the shaded classifier
-tasks.jar {
-    archiveClassifier = "original"
-}
+// This is the base JAR with an "original" classifier, it's not shaded and should become the default JAR after making
+// DBeaver use the shaded classifier
+tasks.jar { archiveClassifier = "original" }
 
-tasks.named("compileJava") {
-    dependsOn(":jdbc-core:build")
-}
+tasks.named("compileJava") { dependsOn(":jdbc-core:build") }
 
 tasks.assemble {
     dependsOn(tasks.shadowJar)
@@ -105,13 +102,7 @@ tasks.assemble {
 
 // Configure publishing to include the shaded JAR after evaluation
 afterEvaluate {
-   publishing {
-       publications {
-           named<MavenPublication>("mavenJava") {
-               artifact(shadedJar.get()) {
-                   classifier = "shaded"
-               }
-           }
-       }
-   }
+    publishing {
+        publications { named<MavenPublication>("mavenJava") { artifact(shadedJar.get()) { classifier = "shaded" } } }
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,19 @@
 rootProject.name = "jdbc-build"
 
 include(":jdbc")
+
 include(":spark-datasource")
+
 include(":jdbc-core")
+
 include(":jdbc-grpc")
+
 include(":jdbc-http")
+
 include(":jdbc-proto")
+
 include(":jdbc-util")
+
 include(":jdbc-reference")
+
 include(":verification")

--- a/spark-datasource/build.gradle.kts
+++ b/spark-datasource/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 description = "Spark Datasource for Salesforce Data Cloud JDBC"
+
 val mavenName: String by extra("Spark Datasource for Salesforce Data Cloud JDBC")
 val mavenDescription: String by extra("${project.description}")
 
@@ -15,7 +16,7 @@ dependencies {
     implementation(project(":jdbc-util"))
     implementation(libs.bundles.grpc.impl)
     implementation(libs.bundles.spark)
-    
+
     // Override transitive Jackson Scala module from Spark with newer version
     implementation(libs.jackson.module.scala)
 
@@ -27,12 +28,10 @@ dependencies {
 }
 
 tasks {
-    test{
+    test {
         useJUnitPlatform {
             includeEngines("scalatest")
-            testLogging {
-                events("passed", "skipped", "failed")
-            }
+            testLogging { events("passed", "skipped", "failed") }
         }
     }
 }

--- a/verification/build.gradle.kts
+++ b/verification/build.gradle.kts
@@ -1,117 +1,122 @@
 plugins {
-  id("base-conventions")
-  id("version-conventions")
-  id("dev.adamko.dev-publish")
+    id("base-conventions")
+    id("version-conventions")
+    id("dev.adamko.dev-publish")
+    id("jacoco-report-aggregation")
 }
 
 dependencies {
-  devPublication(project(":jdbc"))
-  devPublication(project(":jdbc-core"))
-  devPublication(project(":jdbc-proto"))
-  devPublication(project(":jdbc-grpc"))
-  devPublication(project(":jdbc-http"))
-  devPublication(project(":jdbc-util"))
+    devPublication(project(":jdbc"))
+    devPublication(project(":jdbc-core"))
+    devPublication(project(":jdbc-proto"))
+    devPublication(project(":jdbc-grpc"))
+    devPublication(project(":jdbc-http"))
+    devPublication(project(":jdbc-util"))
 }
 
 tasks.named("updateDevRepo") {
-  dependsOn(":jdbc:publishAllToDevRepo")
-  dependsOn(":jdbc-core:publishAllToDevRepo") 
-  dependsOn(":jdbc-proto:publishAllToDevRepo")
-  dependsOn(":jdbc-grpc:publishAllToDevRepo")
-  dependsOn(":jdbc-http:publishAllToDevRepo")
-  dependsOn(":jdbc-util:publishAllToDevRepo")
+    dependsOn(":jdbc:publishAllToDevRepo")
+    dependsOn(":jdbc-core:publishAllToDevRepo")
+    dependsOn(":jdbc-proto:publishAllToDevRepo")
+    dependsOn(":jdbc-grpc:publishAllToDevRepo")
+    dependsOn(":jdbc-http:publishAllToDevRepo")
+    dependsOn(":jdbc-util:publishAllToDevRepo")
 }
 
 tasks.named("check") {
-  dependsOn(tasks.updateDevRepo)
+    dependsOn(tasks.updateDevRepo)
 
-  group = "verification"
-  description = "Verifies that all subprojects produce required JAR artifacts"
+    group = "verification"
+    description = "Verifies that all subprojects produce required JAR artifacts"
 
-  val expectedVersion = provider { "$version" }
+    val expectedVersion = provider { "$version" }
 
-  val repo = devPublish.devMavenRepo.file("com/salesforce/datacloud/").get().asFile
+    val repo = devPublish.devMavenRepo.file("com/salesforce/datacloud/").get().asFile
 
-  doLast {
-    val expectedPublications = setOf("jdbc", "jdbc-grpc", "jdbc-proto", "jdbc-core", "jdbc-util", "jdbc-http")
-    val shaded = setOf("jdbc")
+    doLast {
+        val expectedPublications = setOf("jdbc", "jdbc-grpc", "jdbc-proto", "jdbc-core", "jdbc-util", "jdbc-http")
+        val shaded = setOf("jdbc")
 
-    val resolvedVersion = expectedVersion.get()
+        val resolvedVersion = expectedVersion.get()
 
-    fun hasJar(artifactId: String, version: String, classifier: String? = null): Boolean {
-      val versionDir = repo.resolve("${artifactId}/${version}")
-      
-      if (!versionDir.exists()) {
-        logger.lifecycle("Directory does not exist: ${versionDir.absolutePath}")
-        return false
-      }
-      
-      val classifierPart = classifier?.let { "-$it" } ?: ""
-      
-      // Check for exact version match (non-snapshot)
-      val exactFile = versionDir.resolve("${artifactId}-${version}${classifierPart}.jar")
-      if (exactFile.exists()) {
-        logger.lifecycle("Found exact version match: ${exactFile.name}")
-        return true
-      }
-      
-      // Check for snapshot version with timestamp (if it's a snapshot)
-      if (version.endsWith("-SNAPSHOT")) {
-        // Look for timestamp pattern like: artifactId-version-timestamp-number-classifier.jar
-        val snapshotFiles = versionDir.listFiles { file -> 
-          file.isFile && 
-          file.name.matches("${artifactId}-.*${classifierPart}\\.jar".toRegex()) && 
-          !file.name.endsWith("-SNAPSHOT${classifierPart}.jar")
+        fun hasJar(artifactId: String, version: String, classifier: String? = null): Boolean {
+            val versionDir = repo.resolve("${artifactId}/${version}")
+
+            if (!versionDir.exists()) {
+                logger.lifecycle("Directory does not exist: ${versionDir.absolutePath}")
+                return false
+            }
+
+            val classifierPart = classifier?.let { "-$it" } ?: ""
+
+            // Check for exact version match (non-snapshot)
+            val exactFile = versionDir.resolve("${artifactId}-${version}${classifierPart}.jar")
+            if (exactFile.exists()) {
+                logger.lifecycle("Found exact version match: ${exactFile.name}")
+                return true
+            }
+
+            // Check for snapshot version with timestamp (if it's a snapshot)
+            if (version.endsWith("-SNAPSHOT")) {
+                // Look for timestamp pattern like: artifactId-version-timestamp-number-classifier.jar
+                val snapshotFiles =
+                    versionDir.listFiles { file ->
+                        file.isFile &&
+                            file.name.matches("${artifactId}-.*${classifierPart}\\.jar".toRegex()) &&
+                            !file.name.endsWith("-SNAPSHOT${classifierPart}.jar")
+                    }
+
+                if (snapshotFiles?.isNotEmpty() == true) {
+                    logger.lifecycle("Found snapshot version: ${snapshotFiles.first().name}")
+                    return true
+                }
+            }
+
+            logger.lifecycle("No matching JAR found for ${artifactId}-${version}${classifierPart}.jar")
+            return false
         }
-        
-        if (snapshotFiles?.isNotEmpty() == true) {
-          logger.lifecycle("Found snapshot version: ${snapshotFiles.first().name}")
-          return true
+
+        val failures = mutableListOf<String>()
+        val verified = mutableListOf<String>()
+
+        expectedPublications.forEach { artifactId ->
+            logger.lifecycle("Verifying artifacts for publication $artifactId:$resolvedVersion...")
+
+            if (!hasJar(artifactId, resolvedVersion)) {
+                failures.add("Publication '$artifactId' is missing main JAR")
+            }
+
+            if (!hasJar(artifactId, resolvedVersion, "sources")) {
+                failures.add("Publication '$artifactId' is missing sources JAR")
+            }
+
+            if (!hasJar(artifactId, resolvedVersion, "javadoc")) {
+                failures.add("Publication '$artifactId' is missing javadoc JAR")
+            }
+
+            if (shaded.contains(artifactId) && !hasJar(artifactId, resolvedVersion, "original")) {
+                failures.add("Publication '$artifactId' is missing original JAR which is required since it's shaded")
+            }
+
+            if (shaded.contains(artifactId) && !hasJar(artifactId, resolvedVersion, "shaded")) {
+                failures.add("Publication '$artifactId' is missing shaded JAR which is required since it's shaded")
+            }
+
+            verified.add(artifactId)
+            logger.lifecycle("  Checked publication: $artifactId version $resolvedVersion")
         }
-      }
-      
-      logger.lifecycle("No matching JAR found for ${artifactId}-${version}${classifierPart}.jar")
-      return false
+
+        if (failures.isNotEmpty()) {
+            failures.forEach { logger.error(it) }
+            throw GradleException(
+                "Artifact verification failed. Some projects are missing required JAR files:\n" +
+                    failures.joinToString("\n")
+            )
+        } else if (!verified.containsAll(expectedPublications)) {
+            val missing = expectedPublications - verified.toSet()
+            throw GradleException("Missing expected publication(s): $missing")
+        } else {
+            logger.lifecycle("All subprojects successfully generated required JAR artifacts.")
+        }
     }
-
-    val failures = mutableListOf<String>()
-    val verified = mutableListOf<String>()
-
-    expectedPublications.forEach { artifactId ->
-      logger.lifecycle("Verifying artifacts for publication $artifactId:$resolvedVersion...")
-
-      if (!hasJar(artifactId, resolvedVersion)) {
-        failures.add("Publication '$artifactId' is missing main JAR")
-      }
-
-      if (!hasJar(artifactId, resolvedVersion, "sources")) {
-        failures.add("Publication '$artifactId' is missing sources JAR")
-      }
-
-      if (!hasJar(artifactId, resolvedVersion, "javadoc")) {
-        failures.add("Publication '$artifactId' is missing javadoc JAR")
-      }
-
-      if (shaded.contains(artifactId) && !hasJar(artifactId, resolvedVersion, "original")) {
-        failures.add("Publication '$artifactId' is missing original JAR which is required since it's shaded")
-      }
-
-      if (shaded.contains(artifactId) && !hasJar(artifactId, resolvedVersion, "shaded")) {
-        failures.add("Publication '$artifactId' is missing shaded JAR which is required since it's shaded")
-      }
-
-      verified.add(artifactId)
-      logger.lifecycle("  Checked publication: $artifactId version $resolvedVersion")
-    }
-
-    if (failures.isNotEmpty()) {
-      failures.forEach { logger.error(it) }
-      throw GradleException("Artifact verification failed. Some projects are missing required JAR files:\n" + failures.joinToString("\n"))
-    } else if (!verified.containsAll(expectedPublications)) {
-      val missing = expectedPublications - verified.toSet()
-      throw GradleException("Missing expected publication(s): $missing")
-    } else {
-      logger.lifecycle("All subprojects successfully generated required JAR artifacts.")
-    }
-  }
 }


### PR DESCRIPTION
1. Adds aggregated jacoco coverage with close to default settings, we can come up with coverage regression settings later
2. Adds formatting for build scripts, I noticed some .kts files had two spaces while others had four, I added spotless config to keep the bikeshedding down