### PR TITLE
ci: be more specific with hyper caching in ci

### DIFF
--- a/.github/workflows/reusable-build-publish.yml
+++ b/.github/workflows/reusable-build-publish.yml
@@ -78,9 +78,13 @@ jobs:
       - name: Cache hyper artifacts
         uses: actions/cache@v4
         with:
-          path: |
+          path: | # include files from downloadHyper and extractHyper tasks, but exclude log files
             .hyper/hyper-*.zip
-            .hyperd/
+            .hyperd/hyperd
+            .hyperd/hyperd.exe
+            .hyperd/*.dll
+            .hyperd/*.dylib
+            .hyperd/*.so
           key: ${{ runner.os }}-hyper-${{ needs.prepare.outputs.hyper_version }}
           restore-keys: ${{ runner.os }}-hyper-${{ needs.prepare.outputs.hyper_version }}
       - name: Extract Hyper


### PR DESCRIPTION
GitHub Actions doesn't really let you inspect its caches, but I suspect since cache misses are uploaded at the end of a job that we're storing log files unnecessarily. 