### PR TITLE
feat: give more detail for failed tests in console

### DIFF
--- a/buildSrc/src/main/kotlin/java-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-base-conventions.gradle.kts
@@ -21,7 +21,9 @@ tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 
     testLogging {
-        events("passed", "skipped", "failed")
+        events("started", "passed", "skipped", "failed", "standardOut", "standardError")
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showCauses = true
         showExceptions = true
         showStandardStreams = true
         showStackTraces = true


### PR DESCRIPTION
Often times to review what happened in a test you'll have to go look at `/build/reports/problems/problems-report.html` but that can be pretty annoying. This change forces gradle to include more detail in the console to make diagnosing test failures faster.