### PR TITLE
feat: adds DataCloudConnection::getSchemaForQueryId

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
@@ -283,6 +283,12 @@ public class DataCloudConnection implements Connection, AutoCloseable {
         return getChunkBasedResultSet(queryId, chunkId, 1);
     }
 
+    public DataCloudResultSet getSchemaForQueryId(String queryId) throws DataCloudJDBCException {
+        val executor = HyperGrpcClientExecutor.forSubmittedQuery(getStub());
+        val infos = executor.getQuerySchema(queryId);
+        return StreamingResultSet.ofSchema(infos, queryId);
+    }
+
     /**
      * Waits indefinitely (see {@link Deadline#infinite()}) for the status of the specified query to satisfy the given predicate,
      * polling until the predicate returns true or the query completes.

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientExecutor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientExecutor.java
@@ -117,6 +117,19 @@ public class HyperGrpcClientExecutor {
                 log);
     }
 
+    public Iterator<QueryInfo> getQuerySchema(String queryId) throws DataCloudJDBCException {
+        return logTimedValue(
+                () -> {
+                    val param = QueryInfoParam.newBuilder()
+                            .setQueryId(queryId)
+                            .setSchemaOutputFormat(OutputFormat.ARROW_IPC)
+                            .build();
+                    return getStub(queryId).getQueryInfo(param);
+                },
+                "getQuerySchema queryId=" + queryId,
+                log);
+    }
+
     public void cancel(String queryId) throws DataCloudJDBCException {
         logTimedValue(
                 () -> {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannel.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannel.java
@@ -15,18 +15,68 @@
  */
 package com.salesforce.datacloud.jdbc.core;
 
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Iterator;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import salesforce.cdp.hyperdb.v1.QueryInfo;
 import salesforce.cdp.hyperdb.v1.QueryResult;
+import salesforce.cdp.hyperdb.v1.QueryResultPartBinary;
 
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class StreamingByteStringChannel implements ReadableByteChannel {
-    private final Iterator<QueryResult> iterator;
+    @AllArgsConstructor
+    private static class ByteStringIterator<T> implements Iterator<Optional<ByteString>> {
+        private final Iterator<T> inner;
+        private final Function<T, QueryResultPartBinary> mapper;
+
+        @Override
+        public boolean hasNext() {
+            return inner.hasNext();
+        }
+
+        @Override
+        public Optional<ByteString> next() {
+            val next = inner.next();
+            val mapped = mapper.apply(next);
+            return Optional.ofNullable(mapped).map(QueryResultPartBinary::getData);
+        }
+    }
+
+    public static StreamingByteStringChannel ofSchema(Iterator<QueryInfo> queryInfos) {
+        val wrapped = new ByteStringIterator<QueryInfo>(queryInfos, QueryInfo::getBinarySchema);
+        return new StreamingByteStringChannel(wrapped);
+    }
+
+    public static StreamingByteStringChannel ofResults(Iterator<QueryResult> queryResults) {
+        val wrapped = new ByteStringIterator<QueryResult>(queryResults, QueryResult::getBinaryPart);
+        return new StreamingByteStringChannel(wrapped);
+    }
+
+    public static StreamingByteStringChannel ofByteStrings(Iterator<ByteString> byteStrings) {
+        val wrapped = new Iterator<Optional<ByteString>>() {
+            @Override
+            public boolean hasNext() {
+                return byteStrings.hasNext();
+            }
+
+            @Override
+            public Optional<ByteString> next() {
+                return Optional.ofNullable(byteStrings.next());
+            }
+        };
+        return new StreamingByteStringChannel(wrapped);
+    }
+
+    private final Iterator<Optional<ByteString>> iterator;
     private boolean open = true;
     private ByteBuffer currentBuffer = null;
 
@@ -41,12 +91,9 @@ public class StreamingByteStringChannel implements ReadableByteChannel {
         // Continue reading while destination has space AND we have data available
         while (dst.hasRemaining() && (iterator.hasNext() || (currentBuffer != null && currentBuffer.hasRemaining()))) {
             if (currentBuffer == null || !currentBuffer.hasRemaining()) {
-                val queryResult = iterator.next();
-                if (queryResult.hasBinaryPart()) {
-                    val data = queryResult.getBinaryPart().getData();
-                    if (!data.isEmpty()) {
-                        currentBuffer = data.asReadOnlyByteBuffer();
-                    }
+                val data = iterator.next();
+                if (data.isPresent() && !data.get().isEmpty()) {
+                    currentBuffer = data.get().asReadOnlyByteBuffer();
                 } else {
                     // This was a non result data query result message like a query info message.
                     // We ignore that message here and will just try to fetch the next message in

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
@@ -38,6 +38,7 @@ import org.apache.calcite.avatica.AvaticaResultSetMetaData;
 import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.QueryState;
+import salesforce.cdp.hyperdb.v1.QueryInfo;
 import salesforce.cdp.hyperdb.v1.QueryResult;
 
 @Slf4j
@@ -69,9 +70,20 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
         return of(iterator, iterator.getQueryId());
     }
 
+    public static StreamingResultSet ofSchema(Iterator<QueryInfo> iterator, String queryId)
+            throws DataCloudJDBCException {
+        val channel = StreamingByteStringChannel.ofSchema(iterator);
+        return of(channel, queryId);
+    }
+
     public static StreamingResultSet of(Iterator<QueryResult> iterator, String queryId) throws DataCloudJDBCException {
+        val channel = StreamingByteStringChannel.ofResults(iterator);
+        return of(channel, queryId);
+    }
+
+    private static StreamingResultSet of(StreamingByteStringChannel channel, String queryId)
+            throws DataCloudJDBCException {
         try {
-            val channel = new StreamingByteStringChannel(iterator);
             val reader = new ArrowStreamReader(channel, new RootAllocator(ROOT_ALLOCATOR_MB_FROM_V2));
             val schemaRoot = reader.getVectorSchemaRoot();
             val columns = toColumnMetaData(schemaRoot.getSchema().getFields());

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannelMemoryTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannelMemoryTest.java
@@ -48,7 +48,7 @@ class StreamingByteStringChannelMemoryTest {
         val allocatedBefore = memoryBean.getHeapMemoryUsage().getUsed();
 
         long totalBytesRead;
-        try (val channel = new StreamingByteStringChannel(testData.iterator())) {
+        try (val channel = StreamingByteStringChannel.ofResults(testData.iterator())) {
             totalBytesRead = 0;
 
             // Read all data in small chunks to simulate realistic usage
@@ -99,7 +99,7 @@ class StreamingByteStringChannelMemoryTest {
 
         val testData = createTestData(numChunks, dataSize);
         long totalRead;
-        try (val channel = new StreamingByteStringChannel(testData.iterator())) {
+        try (val channel = StreamingByteStringChannel.ofResults(testData.iterator())) {
 
             ByteBuffer buffer = ByteBuffer.allocate(4096);
             totalRead = 0;
@@ -154,7 +154,7 @@ class StreamingByteStringChannelMemoryTest {
         val before = memoryBean.getHeapMemoryUsage().getUsed();
 
         long totalRead;
-        try (val channel = new StreamingByteStringChannel(variableData.iterator())) {
+        try (val channel = StreamingByteStringChannel.ofResults(variableData.iterator())) {
             ByteBuffer buffer = ByteBuffer.allocate(1024); // Small buffer
 
             totalRead = 0;

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannelTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannelTest.java
@@ -37,7 +37,7 @@ class StreamingByteStringChannelTest {
     @Test
     @SneakyThrows
     void isOpenFollowsNioSemantics() {
-        try (val channel = new StreamingByteStringChannel(empty())) {
+        try (val channel = StreamingByteStringChannel.ofResults(empty())) {
             assertThat(channel.isOpen()).isTrue(); // Channel starts open regardless of data availability
             // Even with no data, channel remains open until explicitly closed
             assertThat(channel.read(ByteBuffer.allocate(1))).isEqualTo(-1); // End-of-stream
@@ -51,7 +51,7 @@ class StreamingByteStringChannelTest {
     @Test
     @SneakyThrows
     void isOpenDetectsIfIteratorHasRemaining() {
-        try (val channel = new StreamingByteStringChannel(some())) {
+        try (val channel = StreamingByteStringChannel.ofResults(some())) {
             assertThat(channel.isOpen()).isTrue();
         }
     }
@@ -59,7 +59,7 @@ class StreamingByteStringChannelTest {
     @Test
     @SneakyThrows
     void readThrowsClosedChannelExceptionWhenClosed() {
-        val channel = new StreamingByteStringChannel(some());
+        val channel = StreamingByteStringChannel.ofResults(some());
         channel.close();
         assertThat(channel.isOpen()).isFalse();
 
@@ -70,7 +70,7 @@ class StreamingByteStringChannelTest {
     @Test
     @SneakyThrows
     void readReturnsNegativeOneOnIteratorExhaustion() {
-        try (val channel = new StreamingByteStringChannel(empty())) {
+        try (val channel = StreamingByteStringChannel.ofResults(empty())) {
             assertThat(channel.read(ByteBuffer.allocateDirect(2))).isEqualTo(-1);
         }
     }
@@ -84,7 +84,7 @@ class StreamingByteStringChannelTest {
 
         val iterator = infiniteStream().peek(seen::add).iterator();
 
-        try (val channel = new ReadChannel(new StreamingByteStringChannel(iterator))) {
+        try (val channel = new ReadChannel(StreamingByteStringChannel.ofResults(iterator))) {
             channel.readFully(first);
             assertThat(seen).hasSize(5);
             channel.readFully(second);

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingResultSetTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingResultSetTest.java
@@ -18,10 +18,12 @@ package com.salesforce.datacloud.jdbc.core;
 import static com.salesforce.datacloud.jdbc.hyper.HyperTestBase.assertEachRowIsTheSame;
 import static com.salesforce.datacloud.jdbc.hyper.HyperTestBase.getHyperQueryConnection;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.salesforce.datacloud.jdbc.hyper.HyperTestBase;
 import com.salesforce.datacloud.query.v3.QueryStatus;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.SneakyThrows;
@@ -128,6 +130,71 @@ public class StreamingResultSetTest {
         assertThat(witnessed.get())
                 .as("last value seen from query: " + status.getQueryId())
                 .isEqualTo(rows);
+    }
+
+    @SneakyThrows
+    @Test
+    public void testGetSchemaForQueryIdWithZeroResults() {
+        withStatement(none, (conn, stmt) -> {
+            val sql =
+                    "SELECT s, s::text as s_text, cast(s as numeric(38,18)) as s_numeric FROM generate_series(1,10) s LIMIT 0";
+
+            final String queryId;
+            try (val rs = stmt.executeQuery(sql).unwrap(DataCloudResultSet.class)) {
+                queryId = rs.getQueryId();
+                conn.waitFor(queryId, QueryStatus::allResultsProduced);
+            }
+
+            val schemaResultSet = conn.getSchemaForQueryId(queryId);
+            val metaData = schemaResultSet.getMetaData();
+
+            assertThat(metaData.getColumnCount()).as("column count").isEqualTo(3);
+
+            assertThat(metaData.getColumnName(1)).as("integer column").isEqualTo("s");
+            assertThat(metaData.getColumnType(1)).as("integer column").isEqualTo(Types.INTEGER);
+
+            assertThat(metaData.getColumnName(2)).as("text column").isEqualTo("s_text");
+            assertThat(metaData.getColumnType(2)).as("text column").isEqualTo(Types.VARCHAR);
+
+            assertThat(metaData.getColumnName(3)).as("decimal column name").isEqualTo("s_numeric");
+            assertThat(metaData.getColumnType(3)).as("decimal column type").isEqualTo(Types.DECIMAL);
+            assertThat(metaData.getPrecision(3)).as("decimal column precision").isEqualTo(38);
+            assertThat(metaData.getScale(3)).as("decimal column scale").isEqualTo(18);
+
+            assertFalse(schemaResultSet.next());
+        });
+    }
+
+    @SneakyThrows
+    @Test
+    public void testGetSchemaForQueryIdWithResults() {
+        withStatement(none, (conn, stmt) -> {
+            val sql = "SELECT s, s::text as s_text, cast(s as numeric(38,18)) as s_numeric FROM generate_series(1,3) s";
+
+            final String queryId;
+            try (val rs = stmt.executeQuery(sql).unwrap(DataCloudResultSet.class)) {
+                queryId = rs.getQueryId();
+                conn.waitFor(queryId, QueryStatus::allResultsProduced);
+            }
+
+            val schemaResultSet = conn.getSchemaForQueryId(queryId);
+            val metaData = schemaResultSet.getMetaData();
+
+            assertThat(metaData.getColumnCount()).as("column count").isEqualTo(3);
+
+            assertThat(metaData.getColumnName(1)).as("integer column").isEqualTo("s");
+            assertThat(metaData.getColumnType(1)).as("integer column").isEqualTo(Types.INTEGER);
+
+            assertThat(metaData.getColumnName(2)).as("text column").isEqualTo("s_text");
+            assertThat(metaData.getColumnType(2)).as("text column").isEqualTo(Types.VARCHAR);
+
+            assertThat(metaData.getColumnName(3)).as("decimal column name").isEqualTo("s_numeric");
+            assertThat(metaData.getColumnType(3)).as("decimal column type").isEqualTo(Types.DECIMAL);
+            assertThat(metaData.getPrecision(3)).as("decimal column precision").isEqualTo(38);
+            assertThat(metaData.getScale(3)).as("decimal column scale").isEqualTo(18);
+
+            assertFalse(schemaResultSet.next()); // false because getSchemaForQueryId only returns schema info, no rows
+        });
     }
 
     @FunctionalInterface


### PR DESCRIPTION
When a result set returns no rows it can be difficult to work with when using async query methods. Now when you detect that your result set has no rows by using `DataCloudConnection::waitFor` you can use `DataCloudConnection::getSchemaForQueryId` which will return a result set with a schema wired up. 

A logical extension from this would be `getResultSetForQueryId` which could just be a refactor to `AdaptiveQueryResultIterator` to add an overload that accepts a query id and either acquires the results or an empty result set with a schema depending on what it detects about that query.