### PR TITLE
chore: Shorten the license header

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/config/KeywordResources.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/config/KeywordResources.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.config;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/config/QueryResources.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/config/QueryResources.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.config;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ArrowStreamReaderCursor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ArrowStreamReaderCursor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ConnectionProperties.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ConnectionProperties.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionString.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionString.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadata.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadata.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudJdbcManagedChannel.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudJdbcManagedChannel.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatement.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatement.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudResultSet.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientExecutor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientExecutor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/HyperGrpcStubProvider.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/HyperGrpcStubProvider.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/JdbcDriverStubProvider.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/JdbcDriverStubProvider.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/MetadataCursor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/MetadataCursor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/MetadataResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/MetadataResultSet.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ParameterManager.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ParameterManager.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/QueryDBMetadata.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/QueryDBMetadata.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/QueryMetadataUtil.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/QueryMetadataUtil.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/QueryResultSetMetadata.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/QueryResultSetMetadata.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StatementProperties.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StatementProperties.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannel.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannel.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessorFactory.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessorFactory.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseIntVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseIntVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseListVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseListVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BinaryVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BinaryVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BooleanVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BooleanVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArray.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArray.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorGetter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorGetter.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DecimalVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DecimalVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DoubleVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DoubleVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/LargeListVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/LargeListVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/ListVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/ListVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/NumericGetter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/NumericGetter.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorGetter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorGetter.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorGetter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorGetter.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/AdaptiveQueryResultIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/AdaptiveQueryResultIterator.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.fsm;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/AsyncQueryResultHandle.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/AsyncQueryResultHandle.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.fsm;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/InitialQueryInfoUtility.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/InitialQueryInfoUtility.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.fsm;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/QueryResultHandle.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/QueryResultHandle.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.fsm;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/QueryResultIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/fsm/QueryResultIterator.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.fsm;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/model/ParameterBinding.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/model/ParameterBinding.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.model;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/ChunkBased.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/ChunkBased.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.partial;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPolling.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPolling.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.partial;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/RowBased.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/partial/RowBased.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.partial;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/exception/QueryExceptionHandler.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/exception/QueryExceptionHandler.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.exception;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/AuthorizationHeaderInterceptor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/AuthorizationHeaderInterceptor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/HeaderMutatingClientInterceptor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/HeaderMutatingClientInterceptor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/MetadataUtilities.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/MetadataUtilities.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/NetworkTimeoutInterceptor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/NetworkTimeoutInterceptor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/QueryIdHeaderInterceptor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/QueryIdHeaderInterceptor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/SingleHeaderMutatingClientInterceptor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/SingleHeaderMutatingClientInterceptor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/TracingHeadersInterceptor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/TracingHeadersInterceptor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/ArrowToColumnTypeMapper.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/ArrowToColumnTypeMapper.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/ArrowUtils.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/ArrowUtils.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/ColumnType.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/ColumnType.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/Constants.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/Constants.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/DateTimeUtils.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/DateTimeUtils.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/Deadline.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/Deadline.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/DirectDataCloudConnection.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/DirectDataCloudConnection.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/QueryTimeout.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/QueryTimeout.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/VectorPopulator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/util/VectorPopulator.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/query/v3/QueryStatus.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/query/v3/QueryStatus.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.query.v3;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/config/QueryResourcesTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/config/QueryResourcesTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.config;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/ArrowStreamReaderCursorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/ArrowStreamReaderCursorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/AsyncStreamingResultSetTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/AsyncStreamingResultSetTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionFunctionalTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionHeadersTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionHeadersTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionStringTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionStringTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadataTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadataTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudJdbcManagedChannelTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudJdbcManagedChannelTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatementHyperTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatementHyperTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatementTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatementTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementFunctionalTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudStatementTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DefaultParameterManagerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DefaultParameterManagerTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/Float4VectorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/Float4VectorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientRetryTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientRetryTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcTestBase.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcTestBase.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCLimitsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCLimitsTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCReferenceTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCReferenceTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertiesTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertiesTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertyBasedHeadersTests.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertyBasedHeadersTests.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryDBMetadataTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryDBMetadataTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryJDBCAccessorFactoryTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryJDBCAccessorFactoryTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryJDBCDataCursorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryJDBCDataCursorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryResultSetMetadataTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryResultSetMetadataTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryTimeoutTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryTimeoutTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StatementPropertiesTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StatementPropertiesTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannelMemoryTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannelMemoryTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannelTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingByteStringChannelTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingResultSetTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamingResultSetTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessorAssert.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessorAssert.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/QueryJDBCAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/SoftAssertions.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/SoftAssertions.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseIntVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseIntVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BinaryVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BinaryVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BooleanVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BooleanVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArrayTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArrayTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DecimalVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DecimalVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DoubleVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DoubleVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/ListVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/ListVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.accessor.impl;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/fsm/AdaptiveQueryResultIteratorFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/fsm/AdaptiveQueryResultIteratorFunctionalTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.fsm;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/fsm/AdaptiveQueryResultIteratorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/fsm/AdaptiveQueryResultIteratorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.fsm;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/ChunkBasedTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/ChunkBasedTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.partial;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingFunctionalTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.partial;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingTests.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/DataCloudQueryPollingTests.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.partial;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/Page.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/Page.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.partial;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/RowBasedTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/partial/RowBasedTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.core.partial;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/CachedChannelsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/CachedChannelsTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.examples;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/ChunkBasedPaginationTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/ChunkBasedPaginationTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.examples;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/ResultScanTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/ResultScanTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.examples;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/RowBasedPaginationTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/RowBasedPaginationTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.examples;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/SubmitQueryAndConsumeResultsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/SubmitQueryAndConsumeResultsTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.examples;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/TimeZoneQuerySettingTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/TimeZoneQuerySettingTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.examples;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/exception/QueryExceptionHandlerTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/exception/QueryExceptionHandlerTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.exception;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/HyperTestBase.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/HyperTestBase.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.hyper;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/AuthorizationHeaderInterceptorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/AuthorizationHeaderInterceptorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/EmittedHeaderTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/EmittedHeaderTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/HeaderMutatingClientInterceptorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/HeaderMutatingClientInterceptorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/QueryIdHeaderInterceptorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/QueryIdHeaderInterceptorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/TracingHeadersInterceptorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/interceptor/TracingHeadersInterceptorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/ArrowUtilsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/ArrowUtilsTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/DateTimeUtilsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/DateTimeUtilsTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/GrpcUtils.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/GrpcUtils.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/HyperLogScope.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/HyperLogScope.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/RealisticArrowGenerator.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/RealisticArrowGenerator.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/RequestRecordingInterceptor.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/RequestRecordingInterceptor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/RootAllocatorTestExtension.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/RootAllocatorTestExtension.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/TestWasNullConsumer.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/TestWasNullConsumer.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/VectorPopulatorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/util/VectorPopulatorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/query/v3/QueryStatusTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/query/v3/QueryStatusTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.query.v3;
 

--- a/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerConfig.java
+++ b/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerConfig.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.hyper;
 

--- a/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerProcess.java
+++ b/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerProcess.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.hyper;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/AuthenticationSettings.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/AuthenticationSettings.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/AuthenticationStrategy.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/AuthenticationStrategy.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/DataCloudToken.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/DataCloudToken.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProcessor.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProcessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/OAuthToken.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/OAuthToken.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/PrivateKeyHelpers.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/PrivateKeyHelpers.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/TokenCache.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/TokenCache.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/TokenProcessor.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/TokenProcessor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/errors/AuthorizationException.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/errors/AuthorizationException.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth.errors;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/model/AuthenticationResponseWithError.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/model/AuthenticationResponseWithError.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth.model;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/model/DataCloudTokenResponse.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/model/DataCloudTokenResponse.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth.model;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/model/OAuthTokenResponse.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/model/OAuthTokenResponse.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth.model;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/ClientBuilder.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/ClientBuilder.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/Constants.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/Constants.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/FormCommand.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/FormCommand.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/HttpClientLogger.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/HttpClientLogger.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/MetadataCacheInterceptor.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/MetadataCacheInterceptor.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/internal/SFDefaultSocketFactoryWrapper.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/internal/SFDefaultSocketFactoryWrapper.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http.internal;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/soql/DataspaceClient.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/soql/DataspaceClient.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.soql;
 

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/soql/DataspaceResponse.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/soql/DataspaceResponse.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.soql;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/AuthenticationSettingsTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/AuthenticationSettingsTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/AuthenticationStrategyTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/AuthenticationStrategyTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProcessorTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProcessorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/OAuthTokenTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/OAuthTokenTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/PrivateKeyHelpersTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/PrivateKeyHelpersTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/PropertiesUtils.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/PropertiesUtils.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/ResponseEnum.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/ResponseEnum.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/TokenCacheImplTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/TokenCacheImplTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.auth;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/http/ClientBuilderTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/http/ClientBuilderTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/http/FormCommandTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/http/FormCommandTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/http/MetadataCacheInterceptorTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/http/MetadataCacheInterceptorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.http;
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/soql/DataspaceClientTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/soql/DataspaceClientTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.soql;
 

--- a/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/ColumnMetadata.java
+++ b/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/ColumnMetadata.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.reference;
 

--- a/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/PostgresReferenceGenerator.java
+++ b/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/PostgresReferenceGenerator.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.reference;
 

--- a/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/ProtocolValue.java
+++ b/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/ProtocolValue.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.reference;
 

--- a/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/ReferenceEntry.java
+++ b/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/ReferenceEntry.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.reference;
 

--- a/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/TypeInfo.java
+++ b/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/TypeInfo.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.reference;
 

--- a/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/ValueWithClass.java
+++ b/jdbc-reference/src/main/java/com/salesforce/datacloud/reference/ValueWithClass.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.reference;
 

--- a/jdbc-reference/src/test/java/com/salesforce/datacloud/reference/ProtocolValuesLoaderTest.java
+++ b/jdbc-reference/src/test/java/com/salesforce/datacloud/reference/ProtocolValuesLoaderTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.reference;
 

--- a/jdbc-reference/src/test/java/com/salesforce/datacloud/reference/ReferenceJsonLoadingTest.java
+++ b/jdbc-reference/src/test/java/com/salesforce/datacloud/reference/ReferenceJsonLoadingTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.reference;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/config/DriverVersion.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/config/DriverVersion.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.config;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/config/ResourceReader.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/config/ResourceReader.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.config;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/exception/DataCloudJDBCException.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/exception/DataCloudJDBCException.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.exception;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/logging/ElapsedLogger.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/logging/ElapsedLogger.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.logging;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/EncodingUtils.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/EncodingUtils.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.tracing;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/TemporaryBuffers.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/TemporaryBuffers.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.tracing;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/Tracer.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/tracing/Tracer.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.tracing;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/PropertiesExtensions.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/PropertiesExtensions.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/PropertyValidator.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/PropertyValidator.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/Require.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/Require.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/Result.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/Result.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/SqlErrorCodes.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/SqlErrorCodes.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/StreamUtilities.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/StreamUtilities.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/StringCompatibility.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/StringCompatibility.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/ThrowingFunction.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/ThrowingFunction.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/ThrowingJdbcSupplier.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/ThrowingJdbcSupplier.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/ThrowingSupplier.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/ThrowingSupplier.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/Unstable.java
+++ b/jdbc-util/src/main/java/com/salesforce/datacloud/jdbc/util/Unstable.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/config/ResourceReaderTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/config/ResourceReaderTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.config;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/EncodingUtilsTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/EncodingUtilsTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.tracing;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/TemporaryBuffersTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/TemporaryBuffersTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.tracing;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/TracerTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/tracing/TracerTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.tracing;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/PropertiesExtensionsTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/PropertiesExtensionsTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/PropertyValidatorTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/PropertyValidatorTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/RequireTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/RequireTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/StreamUtilitiesTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/StreamUtilitiesTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/StringCompatibilityTest.java
+++ b/jdbc-util/src/test/java/com/salesforce/datacloud/jdbc/util/StringCompatibilityTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.util;
 

--- a/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudDatasource.java
+++ b/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudDatasource.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc;
 

--- a/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
+++ b/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriver.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc;
 

--- a/jdbc/src/main/java/com/salesforce/datacloud/jdbc/interceptor/TokenProcessorSupplier.java
+++ b/jdbc/src/main/java/com/salesforce/datacloud/jdbc/interceptor/TokenProcessorSupplier.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc.interceptor;
 

--- a/jdbc/src/test/java/com/salesforce/datacloud/jdbc/DataCloudDatasourceTest.java
+++ b/jdbc/src/test/java/com/salesforce/datacloud/jdbc/DataCloudDatasourceTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc;
 

--- a/jdbc/src/test/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriverTest.java
+++ b/jdbc/src/test/java/com/salesforce/datacloud/jdbc/DataCloudJDBCDriverTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc;
 

--- a/jdbc/src/test/java/com/salesforce/datacloud/jdbc/OrgIntegrationTest.java
+++ b/jdbc/src/test/java/com/salesforce/datacloud/jdbc/OrgIntegrationTest.java
@@ -1,17 +1,6 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */
 package com.salesforce.datacloud.jdbc;
 

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,15 +1,4 @@
-/*
- * Copyright (c) 2024, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
  */


### PR DESCRIPTION
Listing the full header is unnecessary from a legal point of view. Shortening the header makes our code more readable.