### PR TITLE
feat: Add option to specify attached databases in the DataCloudConnection

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ConnectionProperties.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ConnectionProperties.java
@@ -155,11 +155,9 @@ public class ConnectionProperties {
             props.setProperty("userName", userName);
         }
 
-        // Serialize attached databases properties - format: "databases.N.path" and "databases.N.alias"
-        for (int i = 0; i < attachedDatabases.size(); i++) {
+        for (int i = 0; i < attachedDatabases.size(); ++i) {
             AttachedDatabase database = attachedDatabases.get(i);
             props.setProperty("databases." + i + ".path", database.getPath());
-            // Only set alias if it's provided (not empty)
             if (database.hasAlias() && !database.getAlias().isEmpty()) {
                 props.setProperty("databases." + i + ".alias", database.getAlias());
             }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
@@ -66,7 +66,8 @@ public class DataCloudStatement implements Statement, AutoCloseable {
             querySettings.put(
                     "query_timeout", queryTimeout.getServerQueryTimeout().toMillis() + "ms");
         }
-        return HyperGrpcClientExecutor.of(stub, querySettings);
+        val databases = connection.getConnectionProperties().getAttachedDatabases();
+        return HyperGrpcClientExecutor.of(stub, querySettings, databases);
     }
 
     @Getter


### PR DESCRIPTION
This commits adds an option to specify `AttachedDatabase`s in the `DataCloudConnection`.

Example:
```
Properties properties = new Properties();
properties.setProperty("databases.0.path", "lakehouse:<tenant-id>");
properties.setProperty("databases.0.alias", "lakehouse");
```

We enforce that indexes are provided sequentially, without holes and sort the attached databases by index.

Note that this PR will have merge conflicts with Adrians property revamp.
I'll rebase once this lands early next week.