### PR TITLE
fix: resolve DataCloudArray data loss after ResultSet exhaustion

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArray.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArray.java
@@ -12,33 +12,64 @@ import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
-import lombok.val;
 import org.apache.arrow.memory.util.LargeMemoryUtil;
 import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.ValueVector;
 
 public class DataCloudArray implements Array {
 
-    private final FieldVector dataVector;
-    private final long startOffset;
-    private final long valuesCount;
+    private final Object[] data;
+    private final String baseTypeName;
+    private final int baseType;
     protected static final String NOT_SUPPORTED_IN_DATACLOUD_QUERY =
             "Array method is not supported in Data Cloud query";
 
     public DataCloudArray(FieldVector dataVector, long startOffset, long valuesCount) {
-        this.dataVector = dataVector;
-        this.startOffset = startOffset;
-        this.valuesCount = valuesCount;
+        // Extract data immediately during construction (following PostgreSQL JDBC pattern)
+        // This makes the object self-contained and independent of ValueVector lifecycle
+        this.data = extractDataFromVector(dataVector, startOffset, valuesCount);
+        this.baseTypeName = toColumnType(dataVector.getField()).getType().getName();
+        this.baseType = toColumnType(dataVector.getField()).getType().getVendorTypeNumber();
+    }
+
+    /**
+     * Extracts data from ValueVector immediately to avoid lifecycle dependencies.
+     * This follows the same pattern as PostgreSQL JDBC: extract data during construction.
+     */
+    private Object[] extractDataFromVector(FieldVector dataVector, long startOffset, long valuesCount) {
+        // Handle empty array case
+        if (valuesCount <= 0) {
+            return new Object[0];
+        }
+
+        // Validate bounds against actual vector size
+        if (startOffset < 0 || startOffset >= dataVector.getValueCount()) {
+            throw new ArrayIndexOutOfBoundsException(
+                    "Start offset " + startOffset + " is out of bounds for vector size " + dataVector.getValueCount());
+        }
+
+        long endOffset = startOffset + valuesCount;
+        if (endOffset > dataVector.getValueCount()) {
+            throw new ArrayIndexOutOfBoundsException(
+                    "End offset " + endOffset + " exceeds vector size " + dataVector.getValueCount());
+        }
+
+        // Extract data into a new array
+        Object[] result = new Object[LargeMemoryUtil.checkedCastToInt(valuesCount)];
+        for (int i = 0; i < valuesCount; i++) {
+            long index = startOffset + i;
+            result[i] = dataVector.getObject(LargeMemoryUtil.checkedCastToInt(index));
+        }
+        return result;
     }
 
     @Override
     public String getBaseTypeName() {
-        return toColumnType(this.dataVector.getField()).getType().getName();
+        return this.baseTypeName;
     }
 
     @Override
     public int getBaseType() {
-        return toColumnType(this.dataVector.getField()).getType().getVendorTypeNumber();
+        return this.baseType;
     }
 
     @Override
@@ -51,7 +82,7 @@ public class DataCloudArray implements Array {
         if (map != null) {
             throw new DataCloudJDBCException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
         }
-        return getArrayNoBoundCheck(this.dataVector, this.startOffset, this.valuesCount);
+        return this.data;
     }
 
     @Override
@@ -65,8 +96,10 @@ public class DataCloudArray implements Array {
             throw new DataCloudJDBCException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
         }
         checkBoundaries(index, count);
-        val start = LargeMemoryUtil.checkedCastToInt(this.startOffset + index);
-        return getArrayNoBoundCheck(this.dataVector, start, count);
+        int startIndex = (int) index - 1;
+        Object[] result = new Object[count];
+        System.arraycopy(this.data, startIndex, result, 0, count);
+        return result;
     }
 
     @Override
@@ -94,17 +127,26 @@ public class DataCloudArray implements Array {
         // no-op
     }
 
-    private static Object getArrayNoBoundCheck(ValueVector dataVector, long start, long count) {
-        Object[] result = new Object[LargeMemoryUtil.checkedCastToInt(count)];
-        for (int i = 0; i < count; i++) {
-            result[i] = dataVector.getObject(LargeMemoryUtil.checkedCastToInt(start + i));
-        }
-        return result;
-    }
-
     private void checkBoundaries(long index, int count) {
-        if (index < 0 || index + count > this.startOffset + this.valuesCount) {
-            throw new ArrayIndexOutOfBoundsException();
+        // JDBC arrays use 1-based indexing: valid range is 1 <= index <= array.length
+        // Special case: getArray(1, 0) on empty array is valid (returns empty array)
+
+        long dataIndex = index - 1; // Convert to 0-based for internal logic
+
+        // Validate JDBC index bounds
+        if (dataIndex < 0) {
+            throw new ArrayIndexOutOfBoundsException(
+                    "Index " + index + " is invalid (JDBC arrays use 1-based indexing)");
+        }
+        if (dataIndex > this.data.length) {
+            throw new ArrayIndexOutOfBoundsException("Index " + index + " is out of bounds for array size "
+                    + this.data.length + " (JDBC arrays use 1-based indexing)");
+        }
+
+        // Validate count bounds (only check when count > 0)
+        if (count > 0 && (dataIndex + count) > this.data.length) {
+            throw new ArrayIndexOutOfBoundsException("Index " + index + " + count " + count + " exceeds array size "
+                    + this.data.length + " (JDBC arrays use 1-based indexing)");
         }
     }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionFunctionalTest.java
@@ -4,15 +4,22 @@
  */
 package com.salesforce.datacloud.jdbc.core;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.salesforce.datacloud.jdbc.core.accessor.impl.DataCloudArray;
 import com.salesforce.datacloud.jdbc.hyper.HyperTestBase;
 import com.salesforce.datacloud.jdbc.util.HyperLogScope;
+import java.sql.Array;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.SneakyThrows;
 import lombok.val;
-import org.junit.Test;
+import org.apache.arrow.vector.util.Text;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(HyperTestBase.class)
@@ -99,5 +106,102 @@ public class DataCloudConnectionFunctionalTest {
             assertThat(rs.next()).isFalse();
         }
         hyperLogScope.close();
+    }
+
+    @Test
+    public void testUseAfterResultSetClosed() throws SQLException {
+        // Setup the SQL query so that it has a large ARRAY first and then only small ARRAYs. We'll keep the reference
+        // on the first one and validate that it remains valid during the whole execution. The "filler" arrays are setup
+        // in a way so that several chunks are created to ensure test coverage on chunk updates.
+        String query =
+                "SELECT '[abc,def,ghi]'::text[] as a, 0 as g UNION ALL SELECT ARRAY[rpad('', 1024*1024, 'x')] as a, g FROM generate_series(1, 200) g ORDER BY g ASC";
+
+        try (DataCloudConnection connection = HyperTestBase.getHyperQueryConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                ResultSet rs = statement.executeQuery(query);
+                // Access the first row
+                rs.next();
+                Array reference = rs.getArray(1);
+
+                while (rs.next()) {
+                    // We don't modify the reference and thus expect that the data remains unchanged and accessible
+                    // during the runtime of the query
+                    assertThat(((Object[]) reference.getArray()).length).isEqualTo(3);
+                    Object entry = ((Object[]) reference.getArray())[2];
+                    assertThat(entry).isEqualTo(new Text("ghi"));
+                }
+            }
+        }
+    }
+
+    /**
+     * This is a regression test for a Bug where the Array object returned by the ResultSet was invalidated
+     * after the ResultSet was closed / after the ResultSet was moving on between the backing Chunks.
+     */
+    @Test
+    @SneakyThrows
+    public void testDataCloudArrayPersistenceAfterResultSetClose() {
+        // Integration test demonstrating that DataCloudArray data persists after ResultSet is closed
+        // This test would have failed before the fix due to data loss
+        HyperLogScope hyperLogScope = new HyperLogScope();
+        try (val connection = HyperTestBase.getHyperQueryConnection(hyperLogScope.getProperties())) {
+
+            try (val statement = connection.createStatement()) {
+                val query = "SELECT '[abc,null,def,ghi,jkl,mno]'::text[] as strings_";
+
+                List<List<Object>> rows = new ArrayList<>();
+
+                // Process ResultSet and close it
+                try (ResultSet resultSet = statement.executeQuery(query)) {
+                    int columnCount = resultSet.getMetaData().getColumnCount();
+                    while (resultSet.next()) {
+                        rows.add(getNextRow(resultSet, columnCount));
+                    }
+                } // ResultSet is now closed
+
+                // Access array data after ResultSet is closed - this should work now
+                assertThat(rows).hasSize(1);
+                List<Object> row = rows.get(0);
+                assertThat(row).hasSize(1);
+
+                Object obj = row.get(0);
+                assertThat(obj).isInstanceOf(DataCloudArray.class);
+
+                DataCloudArray array = (DataCloudArray) obj;
+                Object[] arrayData = (Object[]) array.getArray();
+
+                // Verify array data is accessible and correct
+                assertThat(arrayData).hasSize(6);
+                assertThat(arrayData[0].toString()).isEqualTo("abc");
+                assertThat(arrayData[1]).isNull(); // NULL value
+                assertThat(arrayData[2].toString()).isEqualTo("def");
+                assertThat(arrayData[3].toString()).isEqualTo("ghi");
+                assertThat(arrayData[4].toString()).isEqualTo("jkl");
+                assertThat(arrayData[5].toString()).isEqualTo("mno");
+
+                // Test JDBC 1-based indexing
+                Object[] subArray = (Object[]) array.getArray(3, 3); // Get elements 3, 4, 5 (def, ghi, jkl)
+                assertThat(subArray).hasSize(3);
+                assertThat(subArray[0].toString()).isEqualTo("def");
+                assertThat(subArray[1].toString()).isEqualTo("ghi");
+                assertThat(subArray[2].toString()).isEqualTo("jkl");
+
+                // Test JDBC 1-based indexing with NULL value
+                Object[] subArrayWithNull = (Object[]) array.getArray(2, 3); // Get elements 2, 3, 4 (null, def, ghi)
+                assertThat(subArrayWithNull).hasSize(3);
+                assertThat(subArrayWithNull[0]).isNull(); // NULL value
+                assertThat(subArrayWithNull[1].toString()).isEqualTo("def");
+                assertThat(subArrayWithNull[2].toString()).isEqualTo("ghi");
+            }
+        }
+        hyperLogScope.close();
+    }
+
+    private List<Object> getNextRow(ResultSet resultSet, int columnCount) throws SQLException {
+        List<Object> row = new ArrayList<>();
+        for (int i = 1; i <= columnCount; i++) {
+            row.add(resultSet.getObject(i));
+        }
+        return row;
     }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArrayTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArrayTest.java
@@ -12,12 +12,15 @@ import com.google.common.collect.ImmutableList;
 import com.salesforce.datacloud.jdbc.core.accessor.SoftAssertions;
 import com.salesforce.datacloud.jdbc.exception.DataCloudJDBCException;
 import com.salesforce.datacloud.jdbc.util.RootAllocatorTestExtension;
+import java.nio.charset.StandardCharsets;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.util.Text;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.assertj.core.api.ThrowingConsumer;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -43,7 +46,9 @@ public class DataCloudArrayTest {
 
     @AfterEach
     public void tearDown() {
-        this.dataVector.close();
+        if (this.dataVector != null) {
+            this.dataVector.close();
+        }
     }
 
     @SneakyThrows
@@ -82,7 +87,7 @@ public class DataCloudArrayTest {
         val values = ImmutableList.of(1, 2, 3);
         dataVector = extension.createIntVector(values);
         val dataCloudArray = new DataCloudArray(dataVector, 0, dataVector.getValueCount());
-        val array = (Object[]) dataCloudArray.getArray(0, 2);
+        val array = (Object[]) dataCloudArray.getArray(1, 2);
         val expected = ImmutableList.of(1, 2).toArray();
         collector.assertThat(array).isEqualTo(expected);
         collector.assertThat(array.length).isEqualTo(expected.length);
@@ -106,6 +111,187 @@ public class DataCloudArrayTest {
         val dataCloudArray = new DataCloudArray(dataVector, 0, dataVector.getValueCount());
         assertThrows(
                 ArrayIndexOutOfBoundsException.class, () -> dataCloudArray.getArray(-1, dataVector.getValueCount()));
+    }
+
+    @SneakyThrows
+    @Test
+    void testGetArrayWithEmptyArray() {
+        // Test empty array case
+        val values = ImmutableList.<Integer>of();
+        dataVector = extension.createIntVector(values);
+        val dataCloudArray = new DataCloudArray(dataVector, 0, 0);
+        val array = (Object[]) dataCloudArray.getArray();
+        collector.assertThat(array).isEmpty();
+        collector.assertThat(array.length).isEqualTo(0);
+    }
+
+    @SneakyThrows
+    @Test
+    void testJdbcArrayBoundaryCompliance() {
+        // Comprehensive test for JDBC Array boundary compliance
+        val values = ImmutableList.of(1, 2, 3);
+        dataVector = extension.createIntVector(values);
+        val dataCloudArray = new DataCloudArray(dataVector, 0, 0); // Empty array
+
+        // VALID CASES (should work)
+        // getArray(1, 0) on empty array - valid JDBC operation
+        val result = (Object[]) dataCloudArray.getArray(1, 0);
+        collector.assertThat(result).isEmpty();
+
+        // INVALID CASES (should fail)
+        // Invalid JDBC index (0-based)
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> dataCloudArray.getArray(0, 0),
+                "Index 0 is invalid (JDBC arrays use 1-based indexing)");
+
+        // Index out of bounds for empty array
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> dataCloudArray.getArray(2, 0),
+                "Index 2 is out of bounds for array size 0");
+
+        // Count exceeds bounds
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> dataCloudArray.getArray(1, 1),
+                "Index 1 + count 1 exceeds array size 0");
+    }
+
+    @SneakyThrows
+    @Test
+    void testJdbcArrayBoundaryComplianceWithNonEmptyArray() {
+        // Test JDBC boundary compliance with non-empty array
+        val values = ImmutableList.of(1, 2, 3);
+        dataVector = extension.createIntVector(values);
+        val dataCloudArray = new DataCloudArray(dataVector, 0, dataVector.getValueCount());
+
+        // VALID CASES
+        // getArray(1, 0) - valid zero count
+        val result1 = (Object[]) dataCloudArray.getArray(1, 0);
+        collector.assertThat(result1).isEmpty();
+
+        // getArray(1, 1) - valid single element
+        val result2 = (Object[]) dataCloudArray.getArray(1, 1);
+        collector.assertThat(result2).hasSize(1);
+        collector.assertThat(result2[0]).isEqualTo(1);
+
+        // getArray(2, 2) - valid range
+        val result3 = (Object[]) dataCloudArray.getArray(2, 2);
+        collector.assertThat(result3).hasSize(2);
+        collector.assertThat(result3[0]).isEqualTo(2);
+        collector.assertThat(result3[1]).isEqualTo(3);
+
+        // INVALID CASES
+        // Invalid JDBC index (0-based)
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> dataCloudArray.getArray(0, 1),
+                "Index 0 is invalid (JDBC arrays use 1-based indexing)");
+
+        // Index out of bounds
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> dataCloudArray.getArray(4, 1),
+                "Index 4 is out of bounds for array size 3");
+
+        // Count exceeds bounds
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> dataCloudArray.getArray(2, 3),
+                "Index 2 + count 3 exceeds array size 3");
+    }
+
+    @SneakyThrows
+    @Test
+    void testGetArrayWithStringArray() {
+        val values = ImmutableList.of("abc", "def", "ghi", "jkl", "mno");
+        dataVector = extension.createVarCharVectorFrom(values);
+        val dataCloudArray = new DataCloudArray(dataVector, 0, dataVector.getValueCount());
+        val array = (Object[]) dataCloudArray.getArray();
+
+        collector.assertThat(array).hasSize(5);
+        // VarCharVector.getObject() returns Text objects, not String objects
+        collector.assertThat(array[0]).isEqualTo(new Text("abc"));
+        collector.assertThat(array[1]).isEqualTo(new Text("def"));
+        collector.assertThat(array[2]).isEqualTo(new Text("ghi"));
+        collector.assertThat(array[3]).isEqualTo(new Text("jkl"));
+        collector.assertThat(array[4]).isEqualTo(new Text("mno"));
+    }
+
+    @SneakyThrows
+    @Test
+    void testGetArrayWithStringArrayAndNulls() {
+        VarCharVector varcharVector = new VarCharVector("test-varchar-vector", extension.getRootAllocator());
+        varcharVector.allocateNew(6);
+
+        // Set values with NULL handling
+        varcharVector.setSafe(0, "abc".getBytes(StandardCharsets.UTF_8));
+        varcharVector.setNull(1); // Set NULL at index 1
+        varcharVector.setSafe(2, "def".getBytes(StandardCharsets.UTF_8));
+        varcharVector.setSafe(3, "ghi".getBytes(StandardCharsets.UTF_8));
+        varcharVector.setSafe(4, "jkl".getBytes(StandardCharsets.UTF_8));
+        varcharVector.setSafe(5, "mno".getBytes(StandardCharsets.UTF_8));
+
+        varcharVector.setValueCount(6);
+
+        dataVector = varcharVector;
+
+        val dataCloudArray = new DataCloudArray(dataVector, 0, dataVector.getValueCount());
+        val array = (Object[]) dataCloudArray.getArray();
+
+        collector.assertThat(array).hasSize(6);
+
+        // VarCharVector.getObject() returns Text objects, not String objects
+        collector.assertThat(array[0]).isEqualTo(new Text("abc"));
+        collector.assertThat(array[1]).isNull();
+        collector.assertThat(array[2]).isEqualTo(new Text("def"));
+        collector.assertThat(array[3]).isEqualTo(new Text("ghi"));
+        collector.assertThat(array[4]).isEqualTo(new Text("jkl"));
+        collector.assertThat(array[5]).isEqualTo(new Text("mno"));
+    }
+
+    @SneakyThrows
+    @Test
+    void testConstructorWithInvalidStartOffset() {
+        // Test extractDataFromVector with invalid start offset (covers line 46-47)
+        val values = ImmutableList.of(1, 2, 3);
+        dataVector = extension.createIntVector(values);
+
+        // Test negative start offset
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new DataCloudArray(dataVector, -1, 2));
+
+        // Test start offset >= vector size
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> new DataCloudArray(dataVector, dataVector.getValueCount(), 1));
+    }
+
+    @SneakyThrows
+    @Test
+    void testConstructorWithInvalidEndOffset() {
+        // Test extractDataFromVector with end offset exceeding vector size (covers line 52-53)
+        val values = ImmutableList.of(1, 2, 3);
+        dataVector = extension.createIntVector(values);
+
+        // Test end offset exceeding vector size
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> new DataCloudArray(dataVector, 1, 3)); // start=1, count=3, end=4 > size=3
+    }
+
+    @SneakyThrows
+    @Test
+    void testGetArrayWithIndexPlusCountExceedingArraySize() {
+        // Test checkBoundaries with index + count exceeding array size (covers line 137-138)
+        val values = ImmutableList.of(1, 2, 3);
+        dataVector = extension.createIntVector(values);
+        val dataCloudArray = new DataCloudArray(dataVector, 0, dataVector.getValueCount());
+
+        // Test index + count exceeding array size (JDBC 1-based indexing)
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> dataCloudArray.getArray(2, 3)); // index=2, count=3, end=4 > size=3
     }
 
     private static Arguments impl(String name, ThrowingConsumer<DataCloudArray> impl) {


### PR DESCRIPTION
- Refactor DataCloudArray to extract and store data during construction
- Fix JDBC array indexing to use proper 1-based indexing
- Add comprehensive tests for string arrays with NULL values

Fixes data loss issue where ValueVector data was lost after ResultSet lifecycle ended, following PostgreSQL JDBC ArrayImpl pattern.