### PR TITLE
fix: update version to 0.35.0 and resolves 409 conflict error in snapshot builds

### DIFF
--- a/.github/workflows/reusable-build-publish.yml
+++ b/.github/workflows/reusable-build-publish.yml
@@ -154,6 +154,7 @@ jobs:
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.publish_pass }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.signing_key }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.signing_pass }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.signing_pub }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_SKIP_TAG: true
       - name: Upload JReleaser logs on failure

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ hyperApiVersion=0.0.22502.r99d1cc31
 
 # Revision here is what is used when producing local and snapshot builds,
 # it is ignored for releases which instead use the tag
-revision=0.30.0
+revision=0.35.0


### PR DESCRIPTION
JReleaser release is failing with a **409 Conflict error** when trying to publish snapshot artifacts to GitHub Packages.



