### PR TITLE
fix: pin JReleaser to version 1.19.0 to resolve GPG signing issues

### DIFF
--- a/.github/workflows/reusable-build-publish.yml
+++ b/.github/workflows/reusable-build-publish.yml
@@ -148,6 +148,8 @@ jobs:
           echo "resolved_version=$RESOLVED_VERSION" >> $GITHUB_OUTPUT
       - name: Publish to Maven Central
         uses: jreleaser/release-action@v2
+        with:
+          version: 1.19.0
         env:
           JRELEASER_PROJECT_VERSION: ${{ steps.resolve_version.outputs.resolved_version }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.publish_user }}


### PR DESCRIPTION
- JReleaser 1.20.0 introduced stricter GPG public key validation
- This caused publishing failures with 'Did not find public key for signing' error
- Pinning to 1.19.0 restores working behavior from previous releases
- Resolves verification, bundle, and publishing issues in release workflow

Fixes publishing failures experienced in version 0.35.0 release.