### PR TITLE
chore: Mark slow tests as skipped

### DIFF
--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionFunctionalTest.java
@@ -19,12 +19,14 @@ import java.util.List;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.apache.arrow.vector.util.Text;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(HyperTestBase.class)
 public class DataCloudConnectionFunctionalTest {
     @Test
+    @Disabled // This test is too slow, executing for 2 minutes
     public void testNetworkTimeoutDefault() throws SQLException {
         // Verify that by default no deadline is set
         HyperLogScope hyperLogScope = new HyperLogScope();
@@ -45,6 +47,7 @@ public class DataCloudConnectionFunctionalTest {
     }
 
     @Test
+    @Disabled // This test is too slow, executing for 2 minutes
     public void testNetworkTimeoutPropagatesToServer() throws SQLException {
         // Verify that when network timeout is set a corresponding deadline is set on the gRPC call level
         HyperLogScope hyperLogScope = new HyperLogScope();
@@ -70,6 +73,7 @@ public class DataCloudConnectionFunctionalTest {
 
     @Test
     @SneakyThrows
+    @Disabled // This test is too slow, executing for 2 minutes
     public void testNetworkTimeoutIsPerGrpcCall() {
         // This is a regression test as we previously had set the deadline on the stub which results in a deadline
         // across all calls made on that stub. While the desired network timeout behavior is that it should

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryTimeoutTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/QueryTimeoutTest.java
@@ -17,6 +17,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -83,6 +84,7 @@ class QueryTimeoutTest {
     }
 
     @Test
+    @Disabled // This test is too slow, executing for 2 minutes
     void testNetworkTimeoutDoesntInterfereWithLocalEnforcement() throws SQLException {
         // Both local enforcement and network timeout integrate with the gRPC deadline mechanism.
         // This test verifies that they don't interfere with each other. If the local enforcement


### PR DESCRIPTION
The four test cases
* DataCloudConnectionFunctionalTest.testNetworkTimeoutDefault
* DataCloudConnectionFunctionalTest.testNetworkTimeoutIsPerGrpcCall
* DataCloudConnectionFunctionalTest.testNetworkTimeoutPropagatesToServer
* QueryTimeoutTest.testNetworkTimeoutDoesntInterfereWithLocalEnforcement

run for roughly 2 minutes, each.

This is unbearable for an efficient development process. Disable the test cases until we prioritize fixing the runtimes.