### PR TITLE
fix: resolve gRPC NameResolver service file merging in shaded JAR

### DIFF
--- a/buildSrc/src/main/kotlin/shading.gradle.kts
+++ b/buildSrc/src/main/kotlin/shading.gradle.kts
@@ -52,7 +52,12 @@ abstract class ShadingExtension @Inject constructor(
             
             isReproducibleFileOrder = true
             isPreserveFileTimestamps = false
-            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+            
+            // Exclude duplicates for non-service files to avoid bloat
+            filesNotMatching("META-INF/services/**") {
+                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            }
             
             // JAR naming configuration
             archiveBaseName.set(project.name)
@@ -74,6 +79,8 @@ abstract class ShadingExtension @Inject constructor(
             relocate("org.apache.commons", "$shadeBase.org.apache.commons")
             relocate("org.apache.hc", "$shadeBase.org.apache.hc")
 
+            // Use built-in service file merging with package relocation support
+            // This automatically handles relocated class names in service files!
             mergeServiceFiles {
                 exclude("META-INF/services/java.sql.Driver")
             }


### PR DESCRIPTION
- Fix IllegalArgumentException: Address types of NameResolver 'unix' not supported
- Root cause: Shadow plugin's duplicatesStrategy=EXCLUDE prevented merging of service files from multiple JARs (grpc-core and grpc-netty)
- Solution: Set duplicatesStrategy=INCLUDE globally, EXCLUDE for non-service files
- Ensures both DnsNameResolverProvider and UdsNameResolverProvider are included
- Resolves URI scheme resolution from unix:// back to proper dns://

Fixes version 0.35.0 regression where shaded JAR was missing critical gRPC providers