### PR TITLE
fix: Remove mandatory clientSecret when using PrivateKey/JWT and fix JWT "audience is invalid" error

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,7 +77,7 @@ In addition, the `salesforce-datacloud` driver supports:
 
 **Authentication Properties:**
 - `clientId`: OAuth client ID (required)
-- `clientSecret`: OAuth client secret (required)
+- `clientSecret`: OAuth client secret (required for password and refresh token auth)
 - `dataspace`: Data space identifier (optional)
 - `userName`: Username for authentication (required for password auth and private key auth)
 - `password`: Password for password authentication (required for password auth)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Properties properties = new Properties();
 properties.put("user", "${userName}");
 properties.put("privateKey", "${privateKey}");
 properties.put("clientId", "${clientId}");
-properties.put("clientSecret", "${clientSecret}");
 ```
 
 #### refresh token authentication:

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProviderTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProviderTest.java
@@ -46,7 +46,6 @@ class DataCloudTokenProviderTest {
     static Properties propertiesForPrivateKey(String userName, String privateKey) {
         val properties = new Properties();
         properties.setProperty(SalesforceAuthProperties.AUTH_CLIENT_ID, "clientId");
-        properties.setProperty(SalesforceAuthProperties.AUTH_CLIENT_SECRET, "clientSecret");
         properties.setProperty(SalesforceAuthProperties.AUTH_USER_NAME, userName);
         properties.setProperty(SalesforceAuthProperties.AUTH_PRIVATE_KEY, privateKey);
         return properties;

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/SalesforceAuthPropertiesTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/SalesforceAuthPropertiesTest.java
@@ -77,7 +77,6 @@ class SalesforceAuthPropertiesTest {
     void parsesPrivateKeyAuthenticationProperties() throws SQLException {
         Properties props = new Properties();
         props.setProperty("clientId", TEST_CLIENT_ID);
-        props.setProperty("clientSecret", TEST_CLIENT_SECRET);
         props.setProperty("userName", TEST_USER_NAME);
         props.setProperty("privateKey", FAKE_PRIVATE_KEY);
         props.setProperty("dataspace", TEST_DATASPACE);
@@ -88,10 +87,22 @@ class SalesforceAuthPropertiesTest {
         assertThat(authProps.getAuthenticationMode())
                 .isEqualTo(SalesforceAuthProperties.AuthenticationMode.PRIVATE_KEY);
         assertThat(authProps.getClientId()).isEqualTo(TEST_CLIENT_ID);
-        assertThat(authProps.getClientSecret()).isEqualTo(TEST_CLIENT_SECRET);
         assertThat(authProps.getUserName()).isEqualTo(TEST_USER_NAME);
         assertThat(authProps.getPrivateKey()).isNotNull();
         assertThat(authProps.getDataspace()).isEqualTo(TEST_DATASPACE);
+    }
+
+    @Test
+    void rejectsClientSecretForPrivateKeyAuthenticationMode() {
+        Properties props = new Properties();
+        props.setProperty("clientId", TEST_CLIENT_ID);
+        props.setProperty("clientSecret", TEST_CLIENT_SECRET); // clientSecret should NOT be provided
+        props.setProperty("userName", TEST_USER_NAME);
+        props.setProperty("privateKey", FAKE_PRIVATE_KEY);
+
+        assertThatThrownBy(() -> SalesforceAuthProperties.ofDestructive(TEST_LOGIN_URL, props))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("clientSecret is not allowed for PRIVATE_KEY/JWT authentication mode");
     }
 
     @Test
@@ -162,7 +173,6 @@ class SalesforceAuthPropertiesTest {
     void toPropertiesRoundtripPrivateKeyAuthentication() throws SQLException {
         Properties props = new Properties();
         props.setProperty("clientId", TEST_CLIENT_ID);
-        props.setProperty("clientSecret", TEST_CLIENT_SECRET);
         props.setProperty("userName", TEST_USER_NAME);
         props.setProperty("privateKey", FAKE_PRIVATE_KEY);
         props.setProperty("dataspace", TEST_DATASPACE);
@@ -220,7 +230,6 @@ class SalesforceAuthPropertiesTest {
     void rejectsInvalidPrivateKeyFormat() {
         Properties props = new Properties();
         props.setProperty("clientId", TEST_CLIENT_ID);
-        props.setProperty("clientSecret", TEST_CLIENT_SECRET);
         props.setProperty("userName", TEST_USER_NAME);
         props.setProperty("privateKey", "invalid-key-format");
 
@@ -233,7 +242,6 @@ class SalesforceAuthPropertiesTest {
     void rejectsCorruptedPrivateKey() {
         Properties props = new Properties();
         props.setProperty("clientId", TEST_CLIENT_ID);
-        props.setProperty("clientSecret", TEST_CLIENT_SECRET);
         props.setProperty("userName", TEST_USER_NAME);
         props.setProperty(
                 "privateKey", "-----BEGIN PRIVATE KEY-----\ninvalid-base64-content\n-----END PRIVATE KEY-----");
@@ -278,7 +286,6 @@ class SalesforceAuthPropertiesTest {
     void privateKeySerializationRoundtrip() throws Exception {
         Properties originalProps = new Properties();
         originalProps.setProperty("clientId", TEST_CLIENT_ID);
-        originalProps.setProperty("clientSecret", TEST_CLIENT_SECRET);
         originalProps.setProperty("userName", TEST_USER_NAME);
         originalProps.setProperty("privateKey", FAKE_PRIVATE_KEY);
 


### PR DESCRIPTION
This change removes the requirement for clientSecret when using PrivateKey/JWT
authentication mode. The clientSecret is not needed for JWT Bearer Token Flow,
as it is not required by the [OAuth 2.0 JWT Bearer Token Flow specification](https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_jwt_flow.htm&type=5).
This is essential for SSO-enabled organizations where password-based authentication
is not available.

Additionally, fixed the JWT audience claim in buildJwt() which was using .add()
with only the hostname, causing "audience is invalid" errors during JWT
authentication. Salesforce requires the audience to be a single string value in
full URL format (e.g., "https://login.salesforce.com").

Changes:
- Remove mandatory check for clientSecret in PrivateKey/JWT authentication mode 
and throws error when present
- Changed JWT audience from .add(hostname) to .single(scheme + "://" + hostname)
- Ensures audience is a single string value instead of an array
- Provides full URL format required by Salesforce OAuth validation

This resolves both the clientSecret requirement issue and the "invalid_grant:
audience is invalid" error when authenticating with JWT Bearer Token flow.