### PR TITLE
fix: Remove required dataspace parameter from Connection

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/HyperDatasource.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/HyperDatasource.java
@@ -4,8 +4,6 @@
  */
 package com.salesforce.datacloud.jdbc;
 
-import static com.salesforce.datacloud.jdbc.util.PropertyParsingUtils.takeOptional;
-
 import com.salesforce.datacloud.jdbc.core.ConnectionProperties;
 import com.salesforce.datacloud.jdbc.core.DataCloudConnection;
 import com.salesforce.datacloud.jdbc.core.GrpcChannelProperties;
@@ -51,7 +49,7 @@ public class HyperDatasource implements DataSource {
 
     @Override
     public Connection getConnection() throws SQLException {
-        return createConnection(host, port, connectionProperties, grpcChannelProperties, dataspace, /*jdbcUrl=*/ null);
+        return createConnection(host, port, connectionProperties, grpcChannelProperties, /*jdbcUrl=*/ null);
     }
 
     /**
@@ -85,11 +83,10 @@ public class HyperDatasource implements DataSource {
             jdbcUrl.addParametersToProperties(properties);
             val connectionProperties = ConnectionProperties.ofDestructive(properties);
             val grpcChannelProperties = GrpcChannelProperties.ofDestructive(properties);
-            String dataspace = takeOptional(properties, "dataspace").orElse("");
             PropertyParsingUtils.validateRemainingProperties(properties);
 
             // Setup the connection
-            return createConnection(host, port, connectionProperties, grpcChannelProperties, dataspace, jdbcUrl);
+            return createConnection(host, port, connectionProperties, grpcChannelProperties, jdbcUrl);
         } catch (SQLException e) {
             log.error("Failed to connect with URL {}: {}", url, e.getMessage(), e);
             throw e;
@@ -107,14 +104,13 @@ public class HyperDatasource implements DataSource {
             int port,
             @NonNull ConnectionProperties connectionProperties,
             @NonNull GrpcChannelProperties grpcChannelProperties,
-            @NonNull String dataspace,
             JdbcURL jdbcUrl)
             throws SQLException {
         port = port == -1 ? 7483 : port;
         ManagedChannelBuilder<?> builder =
                 ManagedChannelBuilder.forAddress(host, port).usePlaintext();
         JdbcDriverStubProvider stubProvider = JdbcDriverStubProvider.of(builder, grpcChannelProperties);
-        return DataCloudConnection.of(stubProvider, connectionProperties, dataspace, jdbcUrl);
+        return DataCloudConnection.of(stubProvider, connectionProperties, jdbcUrl);
     }
 
     @Override

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionHeadersTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionHeadersTest.java
@@ -39,7 +39,7 @@ class DataCloudConnectionHeadersTest {
     @Test
     void deriveHeaders_defaultsOnlyWorkload() throws SQLException {
         ConnectionProperties cp = ConnectionProperties.ofDestructive(new Properties());
-        Metadata md = DataCloudConnection.deriveHeadersFromProperties("", cp);
+        Metadata md = DataCloudConnection.deriveHeadersFromProperties(cp);
         assertThat(md.keys()).containsExactly("user-agent", "x-hyperdb-workload");
     }
 
@@ -50,19 +50,13 @@ class DataCloudConnectionHeadersTest {
         props.setProperty("externalClientContext", "{}");
         ConnectionProperties cp = ConnectionProperties.ofDestructive(props);
 
-        Metadata md = DataCloudConnection.deriveHeadersFromProperties("ds", cp);
+        Metadata md = DataCloudConnection.deriveHeadersFromProperties(cp);
         assertThat(md.keys())
-                .containsExactlyInAnyOrder(
-                        "user-agent",
-                        "x-hyperdb-workload",
-                        "x-hyperdb-external-client-context",
-                        "ctx-dataspace-ds_name");
+                .containsExactlyInAnyOrder("user-agent", "x-hyperdb-workload", "x-hyperdb-external-client-context");
         assertThat(md.get(Metadata.Key.of("x-hyperdb-workload", Metadata.ASCII_STRING_MARSHALLER)))
                 .isEqualTo("wl");
         assertThat(md.get(Metadata.Key.of("x-hyperdb-external-client-context", Metadata.ASCII_STRING_MARSHALLER)))
                 .isEqualTo("{}");
-        assertThat(md.get(Metadata.Key.of("ctx-dataspace-ds_name", Metadata.ASCII_STRING_MARSHALLER)))
-                .isEqualTo("ds");
     }
 
     @Test
@@ -70,7 +64,7 @@ class DataCloudConnectionHeadersTest {
         Properties props = new Properties();
         props.setProperty("workload", "wl");
         try (DataCloudConnection conn =
-                DataCloudConnection.of(new TestStubProvider(), ConnectionProperties.ofDestructive(props), "", null)) {
+                DataCloudConnection.of(new TestStubProvider(), ConnectionProperties.ofDestructive(props), null)) {
             conn.setNetworkTimeout(null, 1000);
             assertThat(conn.getStub()).isNotNull();
         }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionTest.java
@@ -100,7 +100,7 @@ class DataCloudConnectionTest extends InterceptedHyperTestBase {
     @Test
     void testDriverInterceptorsAreAddedWhenStubProviderIsUsed() {
         val stubProvider = new TestStubProvider();
-        val connection = DataCloudConnection.of(stubProvider, ConnectionProperties.defaultProperties(), "", null);
+        val connection = DataCloudConnection.of(stubProvider, ConnectionProperties.defaultProperties(), null);
         connection.getStub();
         // Interceptors should have been added to set the default workload header (x-hyperdb-workload)
         verify(stubProvider.stub).withInterceptors(any(ClientInterceptor[].class));

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/InterceptedHyperTestBase.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/InterceptedHyperTestBase.java
@@ -107,7 +107,7 @@ public class InterceptedHyperTestBase {
                 HyperServiceGrpc.HyperServiceBlockingStub::getQueryResult);
 
         val conn = DataCloudConnection.of(
-                JdbcDriverStubProvider.of(mocked), ConnectionProperties.defaultProperties(), "", null);
+                JdbcDriverStubProvider.of(mocked), ConnectionProperties.defaultProperties(), null);
         connections.add(conn);
         return conn;
     }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCLimitsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCLimitsTest.java
@@ -220,7 +220,6 @@ public class JDBCLimitsTest {
         try (val connection = DataCloudConnection.of(
                 new LargeHeaderChannelConfigStubProvider(server.getPort(), StringUtils.leftPad(" ", 100 * 1024), true),
                 ConnectionProperties.defaultProperties(),
-                "dataspace/unused",
                 null)) {
             try (val stmt = connection.createStatement()) {
                 // We just verify that we are able to get a full response
@@ -234,7 +233,6 @@ public class JDBCLimitsTest {
         try (val connection = DataCloudConnection.of(
                 new LargeHeaderChannelConfigStubProvider(server.getPort(), StringUtils.leftPad(" ", 100 * 1024), false),
                 ConnectionProperties.defaultProperties(),
-                "dataspace/unused",
                 null)) {
             try (val stmt = connection.createStatement()) {
                 assertThatExceptionOfType(SQLException.class).isThrownBy(() -> {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertyBasedHeadersTests.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/PropertyBasedHeadersTests.java
@@ -19,7 +19,7 @@ public class PropertyBasedHeadersTests {
     public void testEmptyPropertiesOnlyContainsWorkload() throws SQLException {
         val properties = new Properties();
         val connectionProperties = ConnectionProperties.ofDestructive(properties);
-        val metadata = DataCloudConnection.deriveHeadersFromProperties("", connectionProperties);
+        val metadata = DataCloudConnection.deriveHeadersFromProperties(connectionProperties);
         assertThat(metadata.keys()).containsExactly("x-hyperdb-workload");
         assertThat(metadata.get(Metadata.Key.of("x-hyperdb-workload", ASCII_STRING_MARSHALLER)))
                 .isEqualTo("jdbcv3");
@@ -32,13 +32,11 @@ public class PropertyBasedHeadersTests {
         properties.setProperty("externalClientContext", "ctx");
         val connectionProperties = ConnectionProperties.ofDestructive(properties);
 
-        val metadata = DataCloudConnection.deriveHeadersFromProperties("", connectionProperties);
+        val metadata = DataCloudConnection.deriveHeadersFromProperties(connectionProperties);
         assertThat(metadata.keys())
-                .containsAll(ImmutableSet.of("x-hyperdb-workload", "dataspace", "x-hyperdb-external-client-context"));
+                .containsAll(ImmutableSet.of("x-hyperdb-workload", "x-hyperdb-external-client-context"));
         assertThat(metadata.get(Metadata.Key.of("x-hyperdb-workload", ASCII_STRING_MARSHALLER)))
                 .isEqualTo("wl");
-        assertThat(metadata.get(Metadata.Key.of("dataspace", ASCII_STRING_MARSHALLER)))
-                .isEqualTo("ds");
         assertThat(metadata.get(Metadata.Key.of("x-hyperdb-external-client-context", ASCII_STRING_MARSHALLER)))
                 .isEqualTo("ctx");
     }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/CachedChannelsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/CachedChannelsTest.java
@@ -54,7 +54,6 @@ public class CachedChannelsTest {
             try (DataCloudConnection conn = DataCloudConnection.of(
                     new InterceptorStubProvider(managedChannel, interceptor),
                     ConnectionProperties.ofDestructive(properties),
-                    "",
                     null)) {
                 try (Statement stmt = conn.createStatement()) {
                     ResultSet rs = stmt.executeQuery("SHOW external_client_context");
@@ -73,7 +72,6 @@ public class CachedChannelsTest {
             try (DataCloudConnection conn = DataCloudConnection.of(
                     new InterceptorStubProvider(managedChannel, interceptor2),
                     ConnectionProperties.ofDestructive(properties),
-                    "",
                     null)) {
                 try (Statement stmt = conn.createStatement()) {
                     ResultSet rs = stmt.executeQuery("SHOW external_client_context");

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/SubmitQueryAndConsumeResultsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/SubmitQueryAndConsumeResultsTest.java
@@ -52,7 +52,7 @@ public class SubmitQueryAndConsumeResultsTest {
                 ConnectionProperties.builder().workload("test-workload").build();
 
         // Use the JDBC Driver interface
-        try (DataCloudConnection conn = DataCloudConnection.of(stubProvider, connectionProperties, "", null)) {
+        try (DataCloudConnection conn = DataCloudConnection.of(stubProvider, connectionProperties, null)) {
             try (Statement stmt = conn.createStatement()) {
                 ResultSet rs = stmt.executeQuery("SELECT s FROM generate_series(1,10) s");
                 while (rs.next()) {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/LocalHyperTestBase.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/LocalHyperTestBase.java
@@ -71,7 +71,7 @@ public class LocalHyperTestBase implements BeforeAllCallback {
                 .intercept(interceptor);
         val stubProvider = JdbcDriverStubProvider.of(channel);
 
-        return DataCloudConnection.of(stubProvider, ConnectionProperties.defaultProperties(), "", null);
+        return DataCloudConnection.of(stubProvider, ConnectionProperties.defaultProperties(), null);
     }
 
     @SneakyThrows

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/QueryInfoIteratorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/QueryInfoIteratorTest.java
@@ -27,7 +27,7 @@ class QueryInfoIteratorTest {
     @SneakyThrows
     void queryInfoIterator_shouldIterateOverQueryInfoMessages() {
         LocalHyperTestBase.assertWithStubProvider(provider -> {
-            try (val connection = DataCloudConnection.of(provider, ConnectionProperties.defaultProperties(), "", null);
+            try (val connection = DataCloudConnection.of(provider, ConnectionProperties.defaultProperties(), null);
                     val stmt = connection.createStatement()) {
                 // Submit a long-running query to get query id
                 ((DataCloudStatement) stmt).executeAsyncQuery("SELECT pg_sleep(10)");
@@ -54,7 +54,7 @@ class QueryInfoIteratorTest {
     @SneakyThrows
     void queryInfoIterator_shouldIterateUntilQueryFinishes() {
         LocalHyperTestBase.assertWithStubProvider(provider -> {
-            try (val connection = DataCloudConnection.of(provider, ConnectionProperties.defaultProperties(), "", null);
+            try (val connection = DataCloudConnection.of(provider, ConnectionProperties.defaultProperties(), null);
                     val stmt = connection.createStatement()) {
                 // Submit a simple query that completes quickly
                 val result = (DataCloudResultSet) stmt.executeQuery("SELECT 1");

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/QuerySchemaAccessorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/QuerySchemaAccessorTest.java
@@ -29,7 +29,7 @@ class QuerySchemaAccessorTest {
     @SneakyThrows
     void getArrowSchema_shouldReturnSchema() {
         LocalHyperTestBase.assertWithStubProvider(provider -> {
-            try (val connection = DataCloudConnection.of(provider, ConnectionProperties.defaultProperties(), "", null);
+            try (val connection = DataCloudConnection.of(provider, ConnectionProperties.defaultProperties(), null);
                     val stmt = connection.createStatement()) {
                 // Submit a query to get query id
                 val result = (DataCloudResultSet) stmt.executeQuery("SELECT 1 as a");

--- a/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudDatasource.java
+++ b/jdbc/src/main/java/com/salesforce/datacloud/jdbc/DataCloudDatasource.java
@@ -157,7 +157,6 @@ public class DataCloudDatasource implements DataSource {
                 connectionProperties,
                 jdbcUrl,
                 authProperties.getUserName(),
-                authProperties.getDataspace(),
                 tokenProvider::getLakehouseName,
                 dataspaceClient);
     }


### PR DESCRIPTION
Previously the DataCloudConnection was special casing `dataspace` so that it was required to be passed as a non-null construction parameter.

Upon further inspection, it turned out that this parameter is not needed at all:
 - For the OAuth based flows it's not required as dataspace is encoded in the JWT
 - For mTLS based flows, dataspace headers will be handled via interceptors on the custom channel. Furthemore, the current implementation is not sufficient anyway, as additional headers would be needed, and those can currently only injected via interceptors, anyway.
 
 Thus there is no scenario that the `dataspace` parameter enables on its own. Hence, the passing of dataspace is removed.