### PR TITLE
docs: Update CODEOWNERS ECCN value to be in compliance w/ salesforce requirements

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
-#ECCN: 5D002.c.1
+#ECCN:Open Source
 #GUSINFO:Open Source,Open Source Workflow
 * datacloud-query-connector-owners@salesforce.com


### PR DESCRIPTION
To remain in compliance w/ Salesforce Open Source policies, we must update ECCN value in CODEOWNERS file to  #ECCN:Open Source. Otherwise datacloud-jdbc repo will be marked as non-compliant and ARCHIVED and later moved to `private` visibility.