### PR TITLE
perf: Optimize ResultSet column lookup with HashMap-based indexing

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ColumnNameResolver.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/ColumnNameResolver.java
@@ -1,0 +1,87 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.avatica.ColumnMetaData;
+
+/**
+ * Resolves column names to their JDBC indices using fast HashMap lookups.
+ *
+ * <p>This class provides O(1) column name lookup instead of O(n) linear search, which is critical
+ * for performance when dealing with large numbers of columns.
+ *
+ * <p>Lookup strategy:
+ * <ol>
+ *   <li>First try exact match (case-sensitive)
+ *   <li>If no exact match, try lowercase match (case-insensitive fallback)
+ * </ol>
+ *
+ * <p>This ensures exact matches are preferred, and case-insensitive matches use the first occurrence
+ * (lowest ordinal) as a tie-breaker. For duplicate column names, the first column with that name
+ * (lowest ordinal) is returned.
+ */
+public final class ColumnNameResolver {
+    private final Map<String, Integer> exactColumnLabelMap;
+    private final Map<String, Integer> lowercaseColumnLabelMap;
+
+    /**
+     * Creates a new ColumnNameResolver from the given column metadata.
+     *
+     * @param columns the column metadata list
+     */
+    public ColumnNameResolver(List<ColumnMetaData> columns) {
+        this.exactColumnLabelMap = new HashMap<>(columns.size());
+        this.lowercaseColumnLabelMap = new HashMap<>(columns.size());
+
+        // First pass: index exact labels to ordinals
+        for (ColumnMetaData columnMetaData : columns) {
+            if (columnMetaData.label != null) {
+                // Use putIfAbsent to ensure first occurrence (lowest ordinal) wins for duplicates
+                exactColumnLabelMap.putIfAbsent(columnMetaData.label, columnMetaData.ordinal);
+            }
+        }
+
+        // Second pass: index lowercase labels to ordinals, but only if the lowercase key doesn't exist yet
+        // This ensures the first column with a given lowercase name wins (lowest ordinal)
+        for (ColumnMetaData columnMetaData : columns) {
+            if (columnMetaData.label != null) {
+                String lowerLabel = columnMetaData.label.toLowerCase();
+                // Only add if this lowercase key hasn't been seen yet (preserves first occurrence)
+                lowercaseColumnLabelMap.putIfAbsent(lowerLabel, columnMetaData.ordinal);
+            }
+        }
+    }
+
+    /**
+     * Finds the JDBC column index (1-based) for the given column label.
+     *
+     * <p>First tries an exact case-sensitive match, then falls back to a case-insensitive match.
+     *
+     * @param columnLabel the column label to find
+     * @return the JDBC column index (1-based)
+     * @throws SQLException if the column is not found
+     */
+    public int findColumn(String columnLabel) throws SQLException {
+        // First try exact match (case-sensitive)
+        Integer index = exactColumnLabelMap.get(columnLabel);
+        if (index != null) {
+            // Avatica uses 0-based ordinals, but JDBC uses 1-based indices
+            return index + 1;
+        }
+
+        // Fallback to lowercase match (case-insensitive)
+        index = lowercaseColumnLabelMap.get(columnLabel.toLowerCase());
+        if (index != null) {
+            // Avatica uses 0-based ordinals, but JDBC uses 1-based indices
+            return index + 1;
+        }
+
+        throw new SQLException("column '" + columnLabel + "' not found", "42703");
+    }
+}

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/MetadataResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/MetadataResultSet.java
@@ -19,6 +19,8 @@ import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.QueryState;
 
 public class MetadataResultSet extends AvaticaResultSet {
+    private final ColumnNameResolver columnNameResolver;
+
     public MetadataResultSet(
             AvaticaStatement statement,
             QueryState state,
@@ -28,6 +30,7 @@ public class MetadataResultSet extends AvaticaResultSet {
             Meta.Frame firstFrame)
             throws SQLException {
         super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
+        this.columnNameResolver = new ColumnNameResolver(signature.columns);
     }
 
     public static AvaticaResultSet of() throws SQLException {
@@ -71,5 +74,62 @@ public class MetadataResultSet extends AvaticaResultSet {
     @Override
     public int getFetchDirection() {
         return ResultSet.FETCH_FORWARD;
+    }
+
+    @Override
+    public int findColumn(String columnLabel) throws SQLException {
+        return columnNameResolver.findColumn(columnLabel);
+    }
+
+    /**
+     * Override getter methods that take String columnLabel to ensure they use our optimized findColumn() method.
+     * This is necessary because Avatica's implementation might use a private method or cache.
+     */
+    @Override
+    public String getString(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getString(columnIndex);
+    }
+
+    @Override
+    public int getInt(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getInt(columnIndex);
+    }
+
+    @Override
+    public long getLong(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getLong(columnIndex);
+    }
+
+    @Override
+    public boolean getBoolean(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getBoolean(columnIndex);
+    }
+
+    @Override
+    public byte getByte(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getByte(columnIndex);
+    }
+
+    @Override
+    public short getShort(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getShort(columnIndex);
+    }
+
+    @Override
+    public float getFloat(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getFloat(columnIndex);
+    }
+
+    @Override
+    public double getDouble(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getDouble(columnIndex);
     }
 }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/StreamingResultSet.java
@@ -31,6 +31,7 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
 
     private final ArrowStreamReaderCursor cursor;
     ThrowingJdbcSupplier<QueryStatus> getQueryStatus;
+    private final ColumnNameResolver columnNameResolver;
 
     private StreamingResultSet(
             ArrowStreamReaderCursor cursor,
@@ -45,6 +46,7 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
         super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
         this.cursor = cursor;
         this.queryId = queryId;
+        this.columnNameResolver = new ColumnNameResolver(signature.columns);
     }
 
     public static StreamingResultSet of(ArrowStreamReader resultStream, String queryId) throws SQLException {
@@ -84,5 +86,62 @@ public class StreamingResultSet extends AvaticaResultSet implements DataCloudRes
     @Override
     public int getRow() {
         return cursor.getRowsSeen();
+    }
+
+    @Override
+    public int findColumn(String columnLabel) throws SQLException {
+        return columnNameResolver.findColumn(columnLabel);
+    }
+
+    /**
+     * Override getter methods that take String columnLabel to ensure they use our optimized findColumn() method.
+     * This is necessary because Avatica's implementation might use a private method or cache.
+     */
+    @Override
+    public String getString(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getString(columnIndex);
+    }
+
+    @Override
+    public int getInt(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getInt(columnIndex);
+    }
+
+    @Override
+    public long getLong(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getLong(columnIndex);
+    }
+
+    @Override
+    public boolean getBoolean(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getBoolean(columnIndex);
+    }
+
+    @Override
+    public byte getByte(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getByte(columnIndex);
+    }
+
+    @Override
+    public short getShort(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getShort(columnIndex);
+    }
+
+    @Override
+    public float getFloat(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getFloat(columnIndex);
+    }
+
+    @Override
+    public double getDouble(String columnLabel) throws SQLException {
+        int columnIndex = findColumn(columnLabel);
+        return getDouble(columnIndex);
     }
 }

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/ColumnNameResolverTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/ColumnNameResolverTest.java
@@ -1,0 +1,193 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.val;
+import org.apache.calcite.avatica.ColumnMetaData;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for ColumnNameResolver.
+ * These tests focus on the column name resolution logic without requiring a database connection
+ * or ResultSet boilerplate.
+ */
+public class ColumnNameResolverTest {
+
+    /**
+     * Creates a ColumnMetaData instance for testing.
+     */
+    private ColumnMetaData createColumnMetaData(int ordinal, String label, int sqlType) {
+        val avaticaType = ColumnMetaData.scalar(sqlType, label, ColumnMetaData.Rep.PRIMITIVE_BOOLEAN);
+        return new ColumnMetaData(
+                ordinal,
+                false, // autoIncrement
+                true, // caseSensitive
+                true, // searchable
+                false, // currency
+                1, // nullable
+                true, // signed
+                10, // displaySize
+                label, // label
+                label, // columnName
+                null, // schemaName
+                0, // precision
+                0, // scale
+                null, // tableName
+                null, // catalogName
+                avaticaType,
+                true, // readOnly
+                false, // writable
+                false, // definitelyWritable
+                "java.lang.String"); // className
+    }
+
+    @Test
+    public void testFindColumnExactMatch() throws SQLException {
+        List<ColumnMetaData> columns = new ArrayList<>();
+        columns.add(createColumnMetaData(0, "Col1", Types.VARCHAR));
+        columns.add(createColumnMetaData(1, "Col2", Types.VARCHAR));
+        columns.add(createColumnMetaData(2, "Col3", Types.VARCHAR));
+
+        ColumnNameResolver resolver = new ColumnNameResolver(columns);
+
+        // Test exact matches
+        assertThat(resolver.findColumn("Col1")).isEqualTo(1); // ordinal 0 -> JDBC index 1
+        assertThat(resolver.findColumn("Col2")).isEqualTo(2); // ordinal 1 -> JDBC index 2
+        assertThat(resolver.findColumn("Col3")).isEqualTo(3); // ordinal 2 -> JDBC index 3
+    }
+
+    @Test
+    public void testFindColumnCaseInsensitiveMatch() throws SQLException {
+        // Create columns with different cases: "Aaa" (ordinal 0), "aaa" (ordinal 1), "AaA" (ordinal 2)
+        List<ColumnMetaData> columns = new ArrayList<>();
+        columns.add(createColumnMetaData(0, "Aaa", Types.VARCHAR));
+        columns.add(createColumnMetaData(1, "aaa", Types.VARCHAR));
+        columns.add(createColumnMetaData(2, "AaA", Types.VARCHAR));
+
+        ColumnNameResolver resolver = new ColumnNameResolver(columns);
+
+        // Exact matches should work
+        assertThat(resolver.findColumn("Aaa")).isEqualTo(1);
+        assertThat(resolver.findColumn("aaa")).isEqualTo(2);
+        assertThat(resolver.findColumn("AaA")).isEqualTo(3);
+
+        // Case-insensitive matches should fall back to first occurrence (lowest ordinal)
+        // "AAA" -> lowercase "aaa" -> matches "Aaa" at ordinal 0 (first processed)
+        assertThat(resolver.findColumn("AAA")).isEqualTo(1);
+        assertThat(resolver.findColumn("aaA")).isEqualTo(1);
+        assertThat(resolver.findColumn("AAa")).isEqualTo(1);
+    }
+
+    @Test
+    public void testFindColumnNotFound() {
+        List<ColumnMetaData> columns = new ArrayList<>();
+        columns.add(createColumnMetaData(0, "Col1", Types.VARCHAR));
+
+        ColumnNameResolver resolver = new ColumnNameResolver(columns);
+
+        // Should throw exception for non-existent column
+        assertThatThrownBy(() -> resolver.findColumn("NonExistent"))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("column 'NonExistent' not found")
+                .hasFieldOrPropertyWithValue("SQLState", "42703");
+    }
+
+    @Test
+    public void testFindColumnWithNullLabels() throws SQLException {
+        // Create columns where some have null labels
+        List<ColumnMetaData> columns = new ArrayList<>();
+        // Column with null label (should be skipped in maps)
+        val columnWithNullLabel = new ColumnMetaData(
+                0,
+                false,
+                true,
+                true,
+                false,
+                1,
+                true,
+                10,
+                null, // null label
+                "col1",
+                null,
+                0,
+                0,
+                null,
+                null,
+                ColumnMetaData.scalar(Types.VARCHAR, "col1", ColumnMetaData.Rep.PRIMITIVE_BOOLEAN),
+                true,
+                false,
+                false,
+                "java.lang.String");
+        columns.add(columnWithNullLabel);
+        columns.add(createColumnMetaData(1, "Col2", Types.VARCHAR));
+
+        ColumnNameResolver resolver = new ColumnNameResolver(columns);
+
+        // Column with null label should not be findable by label
+        assertThatThrownBy(() -> resolver.findColumn("col1"))
+                .isInstanceOf(SQLException.class)
+                .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+        // Column with label should work
+        assertThat(resolver.findColumn("Col2")).isEqualTo(2);
+    }
+
+    @Test
+    public void testEmptyColumns() {
+        // Test with empty column list
+        List<ColumnMetaData> columns = new ArrayList<>();
+
+        ColumnNameResolver resolver = new ColumnNameResolver(columns);
+
+        // Should throw exception for any column lookup
+        assertThatThrownBy(() -> resolver.findColumn("AnyCol"))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("column 'AnyCol' not found")
+                .hasFieldOrPropertyWithValue("SQLState", "42703");
+    }
+
+    @Test
+    public void testMultipleColumnsWithSameLowercase() throws SQLException {
+        // Test the putIfAbsent behavior - first occurrence (lowest ordinal) should win
+        List<ColumnMetaData> columns = new ArrayList<>();
+        columns.add(createColumnMetaData(0, "First", Types.VARCHAR));
+        columns.add(createColumnMetaData(1, "FIRST", Types.VARCHAR));
+        columns.add(createColumnMetaData(2, "FiRsT", Types.VARCHAR));
+
+        ColumnNameResolver resolver = new ColumnNameResolver(columns);
+
+        // Exact matches should work
+        assertThat(resolver.findColumn("First")).isEqualTo(1);
+        assertThat(resolver.findColumn("FIRST")).isEqualTo(2);
+        assertThat(resolver.findColumn("FiRsT")).isEqualTo(3);
+
+        // Case-insensitive match should return first occurrence (ordinal 0)
+        assertThat(resolver.findColumn("first")).isEqualTo(1); // matches "First" at ordinal 0
+    }
+
+    @Test
+    public void testDuplicateColumnNames() throws SQLException {
+        // Test that duplicate column names return the first column (lowest ordinal)
+        List<ColumnMetaData> columns = new ArrayList<>();
+        columns.add(createColumnMetaData(0, "Duplicate", Types.VARCHAR));
+        columns.add(createColumnMetaData(1, "Other", Types.INTEGER));
+        columns.add(createColumnMetaData(2, "Duplicate", Types.VARCHAR));
+
+        ColumnNameResolver resolver = new ColumnNameResolver(columns);
+
+        // When looking up "Duplicate", should return the first occurrence (ordinal 0)
+        assertThat(resolver.findColumn("Duplicate")).isEqualTo(1); // ordinal 0 -> JDBC index 1
+
+        // Other column should still work
+        assertThat(resolver.findColumn("Other")).isEqualTo(2); // ordinal 1 -> JDBC index 2
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCLimitsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/JDBCLimitsTest.java
@@ -216,8 +216,8 @@ public class JDBCLimitsTest {
             // Verify values in the first row
             for (int i = 1; i <= columnCount; i++) {
                 assertThat(result.getInt(i)).isEqualTo(i);
-                // BUG: Column lookup by string has quadratic runtime in Avatica.
-                // assertThat(result.getInt("c"+Integer.toString(i))).isEqualTo(i);
+                // With this its suuuuuper slow (before optimization), but should be fast now
+                assertThat(result.getInt("c" + i)).isEqualTo(i);
             }
 
             // Verify there's only one row

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/MetadataResultSetColumnLookupTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/MetadataResultSetColumnLookupTest.java
@@ -1,0 +1,167 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
+import lombok.val;
+import org.apache.calcite.avatica.AvaticaResultSet;
+import org.apache.calcite.avatica.AvaticaResultSetMetaData;
+import org.apache.calcite.avatica.ColumnMetaData;
+import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.avatica.QueryState;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for MetadataResultSet getter methods with column names.
+ * These tests verify that all getter methods (getString, getInt, getLong, getDouble, etc.)
+ * properly use the ColumnNameResolver through findColumn().
+ *
+ * <p>For comprehensive tests of the column lookup logic itself, see {@link ColumnNameResolverTest}.
+ * For integration tests with a real database, see {@link MetadataResultSetTest}.
+ */
+public class MetadataResultSetColumnLookupTest {
+
+    /**
+     * Creates a ColumnMetaData instance for testing.
+     */
+    private ColumnMetaData createColumnMetaData(int ordinal, String label, int sqlType) {
+        val avaticaType = ColumnMetaData.scalar(sqlType, label, ColumnMetaData.Rep.PRIMITIVE_BOOLEAN);
+        return new ColumnMetaData(
+                ordinal,
+                false, // autoIncrement
+                true, // caseSensitive
+                true, // searchable
+                false, // currency
+                1, // nullable
+                true, // signed
+                10, // displaySize
+                label, // label
+                label, // columnName
+                null, // schemaName
+                0, // precision
+                0, // scale
+                null, // tableName
+                null, // catalogName
+                avaticaType,
+                true, // readOnly
+                false, // writable
+                false, // definitelyWritable
+                "java.lang.String"); // className
+    }
+
+    /**
+     * Creates a MetadataResultSet with the given columns and data.
+     */
+    private AvaticaResultSet createMetadataResultSet(List<ColumnMetaData> columns, List<Object> data)
+            throws SQLException {
+        val signature = new Meta.Signature(
+                columns, null, Collections.emptyList(), Collections.emptyMap(), null, Meta.StatementType.SELECT);
+        val metaData = new AvaticaResultSetMetaData(null, null, signature);
+        return MetadataResultSet.of(null, new QueryState(), signature, metaData, TimeZone.getDefault(), null, data);
+    }
+
+    @Test
+    public void testAllGetterTypes() throws SQLException {
+        List<ColumnMetaData> columns = new ArrayList<>();
+        columns.add(createColumnMetaData(0, "ByteCol", Types.TINYINT));
+        columns.add(createColumnMetaData(1, "ShortCol", Types.SMALLINT));
+        columns.add(createColumnMetaData(2, "IntCol", Types.INTEGER));
+        columns.add(createColumnMetaData(3, "LongCol", Types.BIGINT));
+        columns.add(createColumnMetaData(4, "FloatCol", Types.REAL));
+        columns.add(createColumnMetaData(5, "DoubleCol", Types.DOUBLE));
+        columns.add(createColumnMetaData(6, "BoolCol", Types.BOOLEAN));
+        columns.add(createColumnMetaData(7, "StringCol", Types.VARCHAR));
+
+        List<Object> data = new ArrayList<>();
+        data.add(ImmutableList.of((byte) 10, (short) 20, 30, 40L, 1.5f, 2.5, true, "test"));
+
+        try (val resultSet = createMetadataResultSet(columns, data)) {
+            resultSet.next();
+
+            // Test all getter types with exact match
+            assertThat(resultSet.getByte("ByteCol")).isEqualTo((byte) 10);
+            assertThat(resultSet.getShort("ShortCol")).isEqualTo((short) 20);
+            assertThat(resultSet.getInt("IntCol")).isEqualTo(30);
+            assertThat(resultSet.getLong("LongCol")).isEqualTo(40L);
+            assertThat(resultSet.getFloat("FloatCol")).isEqualTo(1.5f);
+            assertThat(resultSet.getDouble("DoubleCol")).isEqualTo(2.5);
+            assertThat(resultSet.getBoolean("BoolCol")).isTrue();
+            assertThat(resultSet.getString("StringCol")).isEqualTo("test");
+
+            // Test case-insensitive for all types
+            assertThat(resultSet.getByte("bytecol")).isEqualTo((byte) 10);
+            assertThat(resultSet.getShort("shortcol")).isEqualTo((short) 20);
+            assertThat(resultSet.getInt("intcol")).isEqualTo(30);
+            assertThat(resultSet.getLong("longcol")).isEqualTo(40L);
+            assertThat(resultSet.getFloat("floatcol")).isEqualTo(1.5f);
+            assertThat(resultSet.getDouble("doublecol")).isEqualTo(2.5);
+            assertThat(resultSet.getBoolean("boolcol")).isTrue();
+            assertThat(resultSet.getString("stringcol")).isEqualTo("test");
+        }
+    }
+
+    @Test
+    public void testGetterMethodsNotFound() throws SQLException {
+        List<ColumnMetaData> columns = new ArrayList<>();
+        columns.add(createColumnMetaData(0, "Col1", Types.VARCHAR));
+
+        List<Object> data = new ArrayList<>();
+        data.add(ImmutableList.of("value1"));
+
+        try (val resultSet = createMetadataResultSet(columns, data)) {
+            resultSet.next();
+
+            // All getter methods should throw exception for non-existent column
+            assertThatThrownBy(() -> resultSet.getString("NonExistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'NonExistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> resultSet.getInt("NonExistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'NonExistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> resultSet.getLong("NonExistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'NonExistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> resultSet.getBoolean("NonExistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'NonExistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> resultSet.getByte("NonExistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'NonExistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> resultSet.getShort("NonExistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'NonExistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> resultSet.getFloat("NonExistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'NonExistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> resultSet.getDouble("NonExistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'NonExistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+        }
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/MetadataResultSetTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/MetadataResultSetTest.java
@@ -1,0 +1,186 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import static com.salesforce.datacloud.jdbc.hyper.LocalHyperTestBase.assertWithConnection;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Offset.offset;
+
+import com.salesforce.datacloud.jdbc.hyper.LocalHyperTestBase;
+import java.sql.SQLException;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(LocalHyperTestBase.class)
+public class MetadataResultSetTest {
+
+    @Test
+    @SneakyThrows
+    public void testColumnLookupExactMatchPreference() {
+        // Test the exact-match-first behavior with case-sensitive columns
+        // This verifies that exact matches are preferred over case-insensitive matches
+        assertWithConnection(connection -> {
+            // Aaa -> 1 (ordinal 0), aaa -> 2 (ordinal 1), AaA -> 3 (ordinal 2)
+            String sql = "SELECT 1 as \"Aaa\", 2 as \"aaa\", 3 as \"AaA\" FROM (VALUES(1)) AS t";
+
+            val stmt = connection.prepareStatement(sql);
+            val result = stmt.executeQuery();
+            assertThat(result.next()).isTrue();
+
+            // Exact matches should work (case-sensitive)
+            assertThat(result.getInt("Aaa")).isEqualTo(1); // exact match -> ordinal 0 -> index 1
+            assertThat(result.getInt("aaa")).isEqualTo(2); // exact match -> ordinal 1 -> index 2
+            assertThat(result.getInt("AaA")).isEqualTo(3); // exact match -> ordinal 2 -> index 3
+
+            // Case-insensitive matches should fall back to first lowercase occurrence
+            // With putIfAbsent, the first column processed (lowest ordinal) wins
+            // "Aaa" (ordinal 0) is processed first, so it wins for lowercase "aaa"
+            // "AAA" -> lowercase "aaa" -> matches "Aaa" at ordinal 0 (first processed)
+            assertThat(result.getInt("AAA")).isEqualTo(1); // lowercase match -> "Aaa" -> ordinal 0 -> index 1
+            // "aaA" -> lowercase "aaa" -> matches "Aaa" at ordinal 0 (first processed)
+            assertThat(result.getInt("aaA")).isEqualTo(1); // lowercase match -> "Aaa" -> ordinal 0 -> index 1
+
+            // Verify exact matches still work after case-insensitive lookups
+            assertThat(result.getInt("Aaa")).isEqualTo(1);
+            assertThat(result.getInt("aaa")).isEqualTo(2);
+            assertThat(result.getInt("AaA")).isEqualTo(3);
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    public void testColumnLookupAllGetterMethods() {
+        // Test all getter methods with both exact and case-insensitive matches
+        assertWithConnection(connection -> {
+            String sql = "SELECT "
+                    + "123::bigint as \"LongCol\", "
+                    + "true as \"BoolCol\", "
+                    + "42::smallint as \"ShortCol\", "
+                    + "17::smallint as \"ByteCol\", "
+                    + "3.14::real as \"FloatCol\", "
+                    + "2.718::double precision as \"DoubleCol\" "
+                    + "FROM (VALUES(1)) AS t";
+
+            val stmt = connection.prepareStatement(sql);
+            val result = stmt.executeQuery();
+            assertThat(result.next()).isTrue();
+
+            // Test exact matches for all getter types
+            assertThat(result.getLong("LongCol")).isEqualTo(123L);
+            assertThat(result.getBoolean("BoolCol")).isTrue();
+            assertThat(result.getShort("ShortCol")).isEqualTo((short) 42);
+            assertThat(result.getByte("ByteCol")).isEqualTo((byte) 17);
+            assertThat(result.getFloat("FloatCol")).isEqualTo(3.14f, offset(0.001f));
+            assertThat(result.getDouble("DoubleCol")).isEqualTo(2.718, offset(0.001));
+
+            // Test case-insensitive matches for all getter types
+            assertThat(result.getLong("longcol")).isEqualTo(123L);
+            assertThat(result.getBoolean("BOOLCOL")).isTrue();
+            assertThat(result.getShort("ShortCol")).isEqualTo((short) 42);
+            assertThat(result.getByte("bytecol")).isEqualTo((byte) 17);
+            assertThat(result.getFloat("FLOATCOL")).isEqualTo(3.14f, offset(0.001f));
+            assertThat(result.getDouble("doublecol")).isEqualTo(2.718, offset(0.001));
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    public void testColumnLookupNotFound() {
+        // Test that column not found throws appropriate exception
+        assertWithConnection(connection -> {
+            String sql = "SELECT 1 as \"col1\", 2 as \"col2\" FROM (VALUES(1)) AS t";
+            val stmt = connection.prepareStatement(sql);
+            val result = stmt.executeQuery();
+            assertThat(result.next()).isTrue();
+
+            // Test that findColumn throws exception for non-existent column
+            assertThatThrownBy(() -> result.findColumn("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            // Test that all getter methods throw exception for non-existent column
+            assertThatThrownBy(() -> result.getString("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> result.getInt("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> result.getLong("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> result.getBoolean("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> result.getByte("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> result.getShort("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> result.getFloat("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+
+            assertThatThrownBy(() -> result.getDouble("nonexistent"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("column 'nonexistent' not found")
+                    .hasFieldOrPropertyWithValue("SQLState", "42703");
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    public void testMetadataResultSetColumnLookup() {
+        // Test MetadataResultSet column lookup through DatabaseMetaData
+        assertWithConnection(connection -> {
+            val metaData = connection.getMetaData();
+            // getTables returns a MetadataResultSet
+            try (val tables = metaData.getTables(null, null, null, null)) {
+                // Test exact match
+                if (tables.next()) {
+                    // These columns exist in the tables metadata
+                    String tableName = tables.getString("TABLE_NAME");
+                    assertThat(tableName).isNotNull();
+
+                    // Test case-insensitive match
+                    String tableName2 = tables.getString("table_name");
+                    assertThat(tableName2).isEqualTo(tableName);
+
+                    // Test other getter methods
+                    tables.getString("TABLE_SCHEM");
+                    tables.getString("TABLE_CAT");
+                }
+            }
+
+            // getColumns also returns a MetadataResultSet
+            try (val columns = metaData.getColumns(null, null, null, null)) {
+                if (columns.next()) {
+                    // Test exact and case-insensitive matches
+                    columns.getString("COLUMN_NAME");
+                    columns.getString("column_name");
+                    columns.getInt("DATA_TYPE");
+                    columns.getInt("data_type");
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR optimizes column lookup in ResultSet by replacing the existing linear search with a HashMap-based indexing strategy. The change significantly improves performance especially for wide result sets or repeated lookups while preserving full JDBC compatibility.

- Replace O(n) linear search with O(1) HashMap lookup in findColumn()
- Implement two-pass indexing: exact labels and lowercase labels
- Exact matches are preferred over case-insensitive matches
- First occurrence (lowest ordinal) wins for case-insensitive lookups
- Override getter methods (getString, getInt, etc.) to use optimized findColumn()