### PR TITLE
fix(ci): remove explicit SNAPSHOT version from snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,7 +10,6 @@ jobs:
     uses: './.github/workflows/reusable-build-publish.yml'
     with:
       publish: true
-      version: 'SNAPSHOT'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       signing_key: ${{ secrets.GPG_SIGNING_KEY }}


### PR DESCRIPTION
The snapshot workflow was passing version: 'SNAPSHOT' which caused RELEASE_VERSION to be set to just 'SNAPSHOT' instead of a semantic version like '0.42.0-SNAPSHOT'.