### PR TITLE
fix(ci): synchronize Release Please state to resolve empty change set error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,1 @@
 # Changelog
-
-## [0.42.0] - 2025-11-11
-
-### Added
-- Initial automated release pipeline setup
-
-[0.42.0]: https://github.com/forcedotcom/datacloud-jdbc/releases/tag/0.42.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ hyperApiVersion=0.0.23576.r0633e4a4
 
 # Revision here is what is used when producing local and snapshot builds,
 # it is ignored for releases which instead use the tag
-revision=0.42.0
+revision=0.41.0


### PR DESCRIPTION
Synchronize version files to match the last released version (0.41.0):
- Revert gradle.properties from 0.42.0 to 0.41.0 to match manifest
- Remove premature 0.42.0 entry from CHANGELOG.md
- Update test script to use release-pr instead of deprecated manifest-pr

This fixes the state mismatch that was causing Release Please to attempt a snapshot bump with empty change set, resulting in 'Not Found' errors when trying to fetch non-existent PRs.

The repository state is now consistent:
- Last release: 0.41.0
- gradle.properties: 0.41.0
- .release-please-manifest.json: 0.41.0
- CHANGELOG.md: clean (no premature entries)