### PR TITLE
fix(ci): use simple release-type with extra-files for Gradle project

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ hyperApiVersion=0.0.23576.r0633e4a4
 
 # Revision here is what is used when producing local and snapshot builds,
 # it is ignored for releases which instead use the tag
-revision=0.41.0
+revision=0.41.0  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,11 @@
 {
   "packages": {
     ".": {
-      "release-type": "java",
-      "version-file": "gradle.properties",
-      "version-file-prefix": "revision=",
+      "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
-      "extra-files": []
+      "extra-files": [
+        "gradle.properties"
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Switch Release Please configuration to use the 'simple' release type
with 'extra-files' instead of 'version-file' approach. This is the
recommended configuration for Gradle projects since Release Please
doesn't have native Gradle support.

Changes:
- Use 'extra-files' to update gradle.properties instead of version-file
- Add version marker (# x-release-please-version) to gradle.properties
- Remove version-file and version-file-prefix configuration

This fixes the "Empty change set" error by avoiding snapshot bumps
that the 'java' release type was attempting. The 'simple' release type
will now correctly create release PRs (0.41.0 → 0.42.0) based on
conventional commits without trying to create intermediate snapshot
versions.

Tested locally and confirmed it creates proper release PRs with
changelog and version updates.

Test locally with:
```
release-please release-pr --repo-url=forcedotcom/datacloud-jdbc \
  --config-file=release-please-config.json \
  --manifest-file=.release-please-manifest.json \
  --target-branch=<branch-name> \
  --token=\"\$GITHUB_TOKEN\" \
  --dry-run"
```