### PR TITLE
fix(ci): explicitly trigger Maven release workflow from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,18 +8,43 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  trigger-maven-release:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Maven Central publish
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: 'main',
+              inputs: {
+                tag_name: '${{ needs.release-please.outputs.tag_name }}'
+              }
+            });
+            console.log('Triggered Maven Central publish workflow for tag: ${{ needs.release-please.outputs.tag_name }}');

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 
 jobs:
   release-please:
@@ -32,19 +31,22 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Trigger Maven Central publish
         uses: actions/github-script@v7
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const tagName = process.env.TAG_NAME;
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'release.yml',
               ref: 'main',
-              inputs: {
-                tag_name: '${{ needs.release-please.outputs.tag_name }}'
-              }
+              inputs: { tag_name: tagName }
             });
-            console.log('Triggered Maven Central publish workflow for tag: ${{ needs.release-please.outputs.tag_name }}');
+            console.log(`Triggered Maven Central publish workflow for tag: ${tagName}`);


### PR DESCRIPTION
GITHUB_TOKEN-triggered events don't cascade to prevent recursive workflows. When release-please creates a release using GITHUB_TOKEN, the 'release: published' event is suppressed and won't trigger the Maven Central publish workflow.

Solution: explicitly trigger release.yml via workflow_dispatch when a release is created.

Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow