### PR TITLE
feat: Expose query execution statistics in QueryStatus

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/query/v3/QueryExecutionStatistics.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/query/v3/QueryExecutionStatistics.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.query.v3;
+
+import com.salesforce.datacloud.jdbc.util.Unstable;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.Value;
+
+/**
+ * Query execution statistics from Hyper.
+ * Provides metrics about query execution for performance monitoring and analysis.
+ *
+ * <p>These statistics include:
+ * <ul>
+ *   <li><b>wallClockTime</b>: Server-side elapsed wall clock time</li>
+ *   <li><b>rowsProcessed</b>: Total number of rows processed (includes native, BYOL file federation, and BYOL live queries)</li>
+ * </ul>
+ */
+@Value
+@Unstable
+public class QueryExecutionStatistics {
+    /**
+     * Server-side elapsed wall clock time.
+     * This represents the total time spent executing the query on the server.
+     */
+    Duration wallClockTime;
+
+    /**
+     * Total number of rows processed during query execution.
+     * This includes rows from native sources, BYOL file federation, and BYOL live queries.
+     */
+    long rowsProcessed;
+
+    /**
+     * Converts proto QueryExecutionStatistics to Java QueryExecutionStatistics.
+     *
+     * @param proto the proto QueryExecutionStatistics message
+     * @return Optional containing QueryExecutionStatistics if proto is not null, empty otherwise
+     */
+    public static Optional<QueryExecutionStatistics> of(salesforce.cdp.hyperdb.v1.QueryExecutionStatistics proto) {
+        if (proto == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new QueryExecutionStatistics(
+                Duration.ofNanos((long) (proto.getWallClockTime() * 1_000_000_000L)), proto.getRowsProcessed()));
+    }
+}

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/query/v3/QueryStatus.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/query/v3/QueryStatus.java
@@ -19,6 +19,8 @@ import salesforce.cdp.hyperdb.v1.QueryInfo;
  *   <li><b>RESULTS_PRODUCED</b>: The query has completed, and the results are ready for retrieval.</li>
  *   <li><b>FINISHED</b>: The query has finished execution and its results have been persisted, guaranteed to be available until the expiration time.</li>
  * </ul>
+ *
+ * <p>Query execution statistics are available via {@link #getExecutionStatistics()} when provided by the server.
  */
 @Value
 @Unstable
@@ -38,6 +40,8 @@ public class QueryStatus {
     double progress;
 
     CompletionStatus completionStatus;
+
+    QueryExecutionStatistics executionStatistics;
 
     public static boolean allResultsProduced(salesforce.cdp.hyperdb.v1.QueryStatus status) {
         return status.getCompletionStatus() == salesforce.cdp.hyperdb.v1.QueryStatus.CompletionStatus.RESULTS_PRODUCED
@@ -71,7 +75,11 @@ public class QueryStatus {
 
     public static QueryStatus of(salesforce.cdp.hyperdb.v1.QueryStatus s) throws SQLException {
         val completionStatus = of(s.getCompletionStatus());
-        return new QueryStatus(s.getQueryId(), s.getChunkCount(), s.getRowCount(), s.getProgress(), completionStatus);
+        val executionStats = s.hasExecutionStats()
+                ? QueryExecutionStatistics.of(s.getExecutionStats()).orElse(null)
+                : null;
+        return new QueryStatus(
+                s.getQueryId(), s.getChunkCount(), s.getRowCount(), s.getProgress(), completionStatus, executionStats);
     }
 
     private static CompletionStatus of(salesforce.cdp.hyperdb.v1.QueryStatus.CompletionStatus completionStatus)

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/query/v3/QueryExecutionStatisticsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/query/v3/QueryExecutionStatisticsTest.java
@@ -1,0 +1,80 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.query.v3;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.Duration;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+class QueryExecutionStatisticsTest {
+    @Test
+    void testOfWithValidProto() {
+        val proto = salesforce.cdp.hyperdb.v1.QueryExecutionStatistics.newBuilder()
+                .setWallClockTime(1.5)
+                .setRowsProcessed(1000)
+                .build();
+
+        val result = QueryExecutionStatistics.of(proto);
+
+        assertThat(result).isPresent().get().satisfies(stats -> {
+            assertThat(stats.getWallClockTime()).isEqualTo(Duration.ofMillis(1500));
+            assertThat(stats.getRowsProcessed()).isEqualTo(1000);
+        });
+    }
+
+    @Test
+    void testOfWithNull() {
+        val result = QueryExecutionStatistics.of(null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testOfWithZeroValues() {
+        val proto = salesforce.cdp.hyperdb.v1.QueryExecutionStatistics.newBuilder()
+                .setWallClockTime(0.0)
+                .setRowsProcessed(0)
+                .build();
+
+        val result = QueryExecutionStatistics.of(proto);
+
+        assertThat(result).isPresent().get().satisfies(stats -> {
+            assertThat(stats.getWallClockTime()).isEqualTo(Duration.ZERO);
+            assertThat(stats.getRowsProcessed()).isEqualTo(0);
+        });
+    }
+
+    @Test
+    void testOfWithLargeValues() {
+        val proto = salesforce.cdp.hyperdb.v1.QueryExecutionStatistics.newBuilder()
+                .setWallClockTime(123.456)
+                .setRowsProcessed(999999999999L)
+                .build();
+
+        val result = QueryExecutionStatistics.of(proto);
+
+        assertThat(result).isPresent().get().satisfies(stats -> {
+            assertThat(stats.getWallClockTime()).isEqualTo(Duration.ofNanos(123_456_000_000L));
+            assertThat(stats.getRowsProcessed()).isEqualTo(999999999999L);
+        });
+    }
+
+    @Test
+    void testOfPreservesSubSecondPrecision() {
+        val proto = salesforce.cdp.hyperdb.v1.QueryExecutionStatistics.newBuilder()
+                .setWallClockTime(0.009395458)
+                .setRowsProcessed(0)
+                .build();
+
+        val result = QueryExecutionStatistics.of(proto);
+
+        assertThat(result).isPresent().get().satisfies(stats -> {
+            assertThat(stats.getWallClockTime().toNanos()).isGreaterThan(9_000_000L);
+            assertThat(stats.getWallClockTime().toNanos()).isLessThan(10_000_000L);
+        });
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/query/v3/QueryStatusTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/query/v3/QueryStatusTest.java
@@ -91,4 +91,30 @@ class QueryStatusTest {
 
         assertThat(actual).isPresent().map(QueryStatus::getRowCount).get().isEqualTo(rows);
     }
+
+    @Test
+    void testExecutionStatisticsPresent() throws SQLException {
+        val executionStats = salesforce.cdp.hyperdb.v1.QueryExecutionStatistics.newBuilder()
+                .setWallClockTime(2.5)
+                .setRowsProcessed(5000)
+                .build();
+        val queryInfo = queryInfoWith(s -> s.setExecutionStats(executionStats));
+        val actual = QueryStatus.of(queryInfo);
+
+        assertThat(actual).isPresent().get().satisfies(status -> {
+            assertThat(status.getExecutionStatistics()).isNotNull();
+            assertThat(status.getExecutionStatistics().getWallClockTime()).isEqualTo(java.time.Duration.ofMillis(2500));
+            assertThat(status.getExecutionStatistics().getRowsProcessed()).isEqualTo(5000);
+        });
+    }
+
+    @Test
+    void testExecutionStatisticsAbsent() throws SQLException {
+        val queryInfo = queryInfoWith(s -> {}); // No execution stats set
+        val actual = QueryStatus.of(queryInfo);
+
+        assertThat(actual).isPresent().get().satisfies(status -> {
+            assertThat(status.getExecutionStatistics()).isNull();
+        });
+    }
 }


### PR DESCRIPTION
Add QueryExecutionStatistics to surface wall_clock_time and
rows_processed from the GetQueryInfo RPC response. The wallClockTime
field uses Duration to avoid unit ambiguity. Users can access these
metrics on any QueryStatus returned by DataCloudConnection.waitFor().