### PR TITLE
fix: async interrupt race condition, DatabaseMetaData spec violations, metadata integration tests

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadata.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadata.java
@@ -20,6 +20,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -181,34 +182,41 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
         return getSqlKeywords();
     }
 
+    // Used by JDBC clients to discover which scalar numeric functions (e.g. ABS, CEIL) can be used in SQL escape syntax {fn ...}
     @Override
     public String getNumericFunctions() {
-        return null;
+        return "";
     }
 
+    // Used by JDBC clients to discover which scalar string functions (e.g. CONCAT, SUBSTRING) can be used in SQL escape syntax {fn ...}
     @Override
     public String getStringFunctions() {
-        return null;
+        return "";
     }
 
+    // Used by JDBC clients to discover which system functions (e.g. USER, IFNULL) can be used in SQL escape syntax {fn ...}
     @Override
     public String getSystemFunctions() {
-        return null;
+        return "";
     }
 
+    // Used by JDBC clients to discover which time/date functions (e.g. NOW, CURDATE) can be used in SQL escape syntax {fn ...}
     @Override
     public String getTimeDateFunctions() {
-        return null;
+        return "";
     }
 
+    // Used by JDBC clients to escape wildcard characters in DatabaseMetaData search patterns (e.g. getTables, getColumns)
     @Override
     public String getSearchStringEscape() {
         return "\\";
     }
 
+    // Used by JDBC clients to discover which non-alphanumeric characters can appear in unquoted identifier names
+    // is empty to keep it simple for now, too much quoting shouldn't be an issue
     @Override
     public String getExtraNameCharacters() {
-        return null;
+        return "";
     }
 
     @Override
@@ -228,7 +236,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public boolean nullPlusNonNullIsNull() {
-        return false;
+        return true;
     }
 
     @Override
@@ -326,14 +334,16 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
         return true;
     }
 
+    // Intermediate level requires features like dynamic SQL that Hyper does not expose in gRPC protocol
     @Override
     public boolean supportsANSI92IntermediateSQL() {
-        return true;
+        return false;
     }
 
+    // Full level additionally requires assertions, temporary tables with preserve semantics, and domain definitions
     @Override
     public boolean supportsANSI92FullSQL() {
-        return true;
+        return false;
     }
 
     @Override
@@ -613,7 +623,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getDefaultTransactionIsolation() {
-        return Connection.TRANSACTION_SERIALIZABLE;
+        return Connection.TRANSACTION_NONE;
     }
 
     @Override
@@ -647,14 +657,16 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern) {
-        return null;
+    public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getProcedures is not supported");
     }
 
     @Override
     public ResultSet getProcedureColumns(
-            String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern) {
-        return null;
+            String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getProcedureColumns is not supported");
     }
 
     @Override
@@ -806,8 +818,9 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types) {
-        return null;
+    public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getUDTs is not supported");
     }
 
     @Override
@@ -831,19 +844,20 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) {
-        return null;
+    public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) throws SQLException {
+        throw new SQLFeatureNotSupportedException("getSuperTypes is not supported");
     }
 
     @Override
-    public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) {
-        return null;
+    public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
+        throw new SQLFeatureNotSupportedException("getSuperTables is not supported");
     }
 
     @Override
     public ResultSet getAttributes(
-            String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern) {
-        return null;
+            String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getAttributes is not supported");
     }
 
     @Override
@@ -853,7 +867,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getResultSetHoldability() {
-        return 0;
+        return ResultSet.HOLD_CURSORS_OVER_COMMIT;
     }
 
     @Override
@@ -868,7 +882,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getJDBCMajorVersion() {
-        return 1;
+        return 4;
     }
 
     @Override
@@ -878,7 +892,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getSQLStateType() {
-        return 0;
+        return DatabaseMetaData.sqlStateSQL;
     }
 
     @Override
@@ -912,25 +926,28 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public ResultSet getClientInfoProperties() {
-        return null;
+    public ResultSet getClientInfoProperties() throws SQLException {
+        throw new SQLFeatureNotSupportedException("getClientInfoProperties is not supported");
     }
 
     @Override
-    public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern) {
-        return null;
+    public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getFunctions is not supported");
     }
 
     @Override
     public ResultSet getFunctionColumns(
-            String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern) {
-        return null;
+            String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getFunctionColumns is not supported");
     }
 
     @Override
     public ResultSet getPseudoColumns(
-            String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) {
-        return null;
+            String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getPseudoColumns is not supported");
     }
 
     @Override

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/DatabaseAttachInterceptor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/interceptor/DatabaseAttachInterceptor.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.interceptor;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.MethodDescriptor;
+import salesforce.cdp.hyperdb.v1.AttachedDatabase;
+import salesforce.cdp.hyperdb.v1.QueryParam;
+
+/**
+ * A gRPC {@link ClientInterceptor} that attaches a database to every {@code ExecuteQuery} call.
+ *
+ * <p>This interceptor rewrites outgoing {@link QueryParam} messages to
+ * include the configured {@link AttachedDatabase} entry, which makes a Hyper
+ * database available in SQL under the given alias.</p>
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ *   var interceptor = new DatabaseAttachInterceptor("/tmp/test.hyper", "default");
+ *   var channel = ManagedChannelBuilder.forAddress("127.0.0.1", port)
+ *       .usePlaintext()
+ *       .intercept(interceptor)
+ *       .build();
+ * }</pre>
+ */
+public class DatabaseAttachInterceptor implements ClientInterceptor {
+
+    private static final String EXECUTE_QUERY_METHOD = "salesforce.hyperdb.grpc.v1.HyperService/ExecuteQuery";
+
+    private final AttachedDatabase attachedDatabase;
+
+    /**
+     * Creates an interceptor that attaches the given database under the given alias.
+     *
+     * @param databasePath the path to the Hyper database (e.g. a file path or {@code hyper.external:} URI)
+     * @param alias        the SQL alias under which the database is accessible
+     */
+    public DatabaseAttachInterceptor(String databasePath, String alias) {
+        this.attachedDatabase = AttachedDatabase.newBuilder()
+                .setPath(databasePath)
+                .setAlias(alias)
+                .build();
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        ClientCall<ReqT, RespT> call = next.newCall(method, callOptions);
+
+        if (!EXECUTE_QUERY_METHOD.equals(method.getFullMethodName())) {
+            return call;
+        }
+
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(call) {
+            @Override
+            public void sendMessage(ReqT message) {
+                if (message instanceof QueryParam) {
+                    QueryParam original = (QueryParam) message;
+                    @SuppressWarnings("unchecked")
+                    ReqT rewritten = (ReqT) original.toBuilder()
+                            .addDatabases(attachedDatabase)
+                            .build();
+                    super.sendMessage(rewritten);
+                } else {
+                    super.sendMessage(message);
+                }
+            }
+        };
+    }
+}

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
@@ -8,6 +8,7 @@ import com.salesforce.datacloud.jdbc.protocol.CloseableIterator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
@@ -61,25 +62,26 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
             return nextValue.isPresent();
         }
 
-        // Block waiting for next value
+        // Block waiting for next value. The future is hoisted out of the loop so that on interrupt
+        // we close the iterator (triggering gRPC cancellation) and then re-wait on the *same* future
+        // rather than requesting a new one (which would hit "Unfulfilled previous future").
         boolean interrupted = false;
+        CompletableFuture<Optional<T>> future =
+                asyncIterator.next().toCompletableFuture();
         try {
             while (true) {
                 try {
-                    nextValue = asyncIterator.next().toCompletableFuture().get();
+                    nextValue = future.get();
                     if (!nextValue.isPresent()) {
                         done = true;
                     }
                     return nextValue.isPresent();
                 } catch (InterruptedException ie) {
                     interrupted = true;
-                    // This will cause the ongoing call to be stopped and thus the future will get an error element
-                    // which will cause the while loop to exit.
                     try {
                         asyncIterator.close();
                     } catch (Exception ignore) {
                     }
-                    return hasNext();
                 } catch (ExecutionException ee) {
                     Throwable cause = ee.getCause();
                     if (cause instanceof RuntimeException) {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/DatabaseMetadataIntegrationTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/hyper/DatabaseMetadataIntegrationTest.java
@@ -1,0 +1,397 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.hyper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.salesforce.datacloud.jdbc.core.DataCloudConnection;
+import com.salesforce.datacloud.jdbc.core.JdbcDriverStubProvider;
+import com.salesforce.datacloud.jdbc.interceptor.DatabaseAttachInterceptor;
+import io.grpc.ManagedChannelBuilder;
+import java.sql.DatabaseMetaData;
+import java.sql.JDBCType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Integration tests for {@link DatabaseMetaData} methods against a real local Hyper instance.
+ *
+ * <p>Starts a dedicated hyperd with a database (via the {@code -d} flag), then creates
+ * a schema and table covering all supported types. Exercises getTables, getColumns,
+ * getSchemas against the real pg_catalog system tables to verify the SQL queries
+ * and type mapping in {@link com.salesforce.datacloud.jdbc.core.QueryMetadataUtil}.</p>
+ */
+@ExtendWith(LocalHyperTestBase.class)
+@Slf4j
+class DatabaseMetadataIntegrationTest {
+
+    private static final String TEST_SCHEMA = "metadata_test";
+    private static final String TEST_TABLE = "all_types";
+    private static HyperServerProcess server;
+    private static String databasePath;
+
+    @BeforeAll
+    @SneakyThrows
+    static void setupDatabase() {
+        // Start hyperd without service roles (WITH_DATABASE config) so CREATE DATABASE works
+        server = HyperServerManager.get(HyperServerManager.ConfigFile.WITH_DATABASE);
+
+        // Create and populate database entirely via raw gRPC (JDBC-independent)
+        ManagedChannelBuilder<?> channelBuilder =
+                ManagedChannelBuilder.forAddress("127.0.0.1", server.getPort()).usePlaintext();
+        try (val stubProvider = JdbcDriverStubProvider.of(channelBuilder)) {
+            databasePath = HyperDatabaseSetup.createAndPopulateDatabase(
+                    stubProvider.getStub(), TEST_SCHEMA, TEST_TABLE);
+        }
+        log.info("Test database setup complete at: {}", databasePath);
+    }
+
+    // ------------------------------------------------------------------
+    // getSchemas
+    // ------------------------------------------------------------------
+
+    @Test
+    @SneakyThrows
+    void getSchemas_returnsTestSchema() {
+        try (val connection = getConnection()) {
+            val md = connection.getMetaData();
+            val rs = md.getSchemas(null, TEST_SCHEMA);
+
+            assertThat(rs.next()).as("Expected at least one schema row").isTrue();
+            assertThat(rs.getString("TABLE_SCHEM")).isEqualTo(TEST_SCHEMA);
+            assertThat(rs.next()).as("Expected exactly one matching schema").isFalse();
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void getSchemas_unfiltered_includesTestSchema() {
+        try (val connection = getConnection()) {
+            val md = connection.getMetaData();
+            val rs = md.getSchemas();
+
+            val schemas = collectColumn(rs, "TABLE_SCHEM");
+            assertThat(schemas).contains(TEST_SCHEMA);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // getTables
+    // ------------------------------------------------------------------
+
+    @Test
+    @SneakyThrows
+    void getTables_findsTestTable() {
+        try (val connection = getConnection()) {
+            val md = connection.getMetaData();
+            val rs = md.getTables(null, TEST_SCHEMA, TEST_TABLE, null);
+
+            assertThat(rs.next()).as("Expected the test table").isTrue();
+            assertThat(rs.getString("TABLE_SCHEM")).isEqualTo(TEST_SCHEMA);
+            assertThat(rs.getString("TABLE_NAME")).isEqualTo(TEST_TABLE);
+            assertThat(rs.next()).as("Expected exactly one matching table").isFalse();
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void getTables_withSchemaPattern_filtersCorrectly() {
+        try (val connection = getConnection()) {
+            val md = connection.getMetaData();
+            val rs = md.getTables(null, "nonexistent_%", "%", null);
+
+            assertThat(rs.next()).as("Should return no tables for nonexistent schema").isFalse();
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void getTables_withTablePattern_filtersCorrectly() {
+        try (val connection = getConnection()) {
+            val md = connection.getMetaData();
+            val rs = md.getTables(null, TEST_SCHEMA, "nonexistent_%", null);
+
+            assertThat(rs.next()).as("Should return no tables for nonexistent table name").isFalse();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // getColumns — type mapping verification
+    // ------------------------------------------------------------------
+
+    @Test
+    @SneakyThrows
+    void getColumns_returnsAllColumns() {
+        try (val connection = getConnection()) {
+            val md = connection.getMetaData();
+            val rs = md.getColumns(null, TEST_SCHEMA, TEST_TABLE, "%");
+
+            val columns = collectColumnInfo(rs);
+            // The table has 19 columns (including 2 array columns)
+            assertThat(columns).hasSize(19);
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_booleanTypeMappedCorrectly() {
+        // Hyper's format_type returns "boolean" — dbTypeToSql only maps "bool"
+        assertColumnTypeName("col_bool", "boolean");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_smallintTypeMappedCorrectly() {
+        // Hyper's format_type returns "smallint" — dbTypeToSql only maps "int2"
+        assertColumnTypeName("col_smallint", "smallint");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_intTypeMappedCorrectly() {
+        // Hyper's format_type returns "integer" — dbTypeToSql only maps "int4"
+        assertColumnTypeName("col_int", "integer");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_bigintTypeMappedCorrectly() {
+        // Hyper's format_type returns "bigint" — dbTypeToSql only maps "int8"
+        assertColumnTypeName("col_bigint", "bigint");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_doubleTypeMappedCorrectly() {
+        // Hyper's format_type returns "double precision" — dbTypeToSql only maps "float8"
+        assertColumnTypeName("col_double", "double precision");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_numericTypeMappedCorrectly() {
+        assertColumnType("col_numeric_18_2", JDBCType.NUMERIC);
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_textTypeMappedCorrectly() {
+        assertColumnType("col_text", JDBCType.VARCHAR);
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_varcharTypeMappedCorrectly() {
+        // Hyper's format_type returns "character varying(255)" — not mapped by dbTypeToSql
+        assertColumnTypeName("col_varchar_255", "character varying(255)");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_charTypeMappedCorrectly() {
+        // Hyper's format_type returns "character(1)"
+        assertColumnTypeName("col_char_1", "character(1)");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_dateTypeMappedCorrectly() {
+        assertColumnType("col_date", JDBCType.DATE);
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_timeTypeMappedCorrectly() {
+        assertColumnType("col_time", JDBCType.TIME);
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_timestampTypeMappedCorrectly() {
+        assertColumnType("col_timestamp", JDBCType.TIMESTAMP);
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_timestamptzTypeMappedCorrectly() {
+        assertColumnType("col_timestamptz", JDBCType.TIMESTAMP_WITH_TIMEZONE);
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_intervalTypeMapped() {
+        // interval is not in dbTypeToSql — check what Hyper returns
+        assertColumnTypeName("col_interval", "interval");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_jsonTypeMapped() {
+        // json is not in dbTypeToSql — check what Hyper returns
+        assertColumnTypeName("col_json", "json");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_oidTypeMapped() {
+        // oid maps to BIGINT via dbTypeToSql
+        assertColumnType("col_oid", JDBCType.BIGINT);
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_intArrayTypeMapped() {
+        // Hyper's format_type returns "array(integer)" — dbTypeToSql only maps exact "array"
+        assertColumnTypeName("col_int_array", "array(integer)");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_textArrayTypeMapped() {
+        // Hyper's format_type returns "array(text)" — dbTypeToSql only maps exact "array"
+        assertColumnTypeName("col_text_array", "array(text)");
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_nullableColumnReportsNullable() {
+        try (val connection = getConnection()) {
+            val info = getColumnInfo(connection, "col_nullable_int");
+            assertThat(info).isNotNull();
+            assertThat(info.get("NULLABLE"))
+                    .as("col_nullable_int should be nullable")
+                    .isEqualTo(DatabaseMetaData.columnNullable);
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_nonNullableColumnReportsNotNull() {
+        try (val connection = getConnection()) {
+            // col_bool is NOT NULL by default in our CREATE TABLE (no explicit NOT NULL, but Hyper
+            // reports nullable for all columns unless explicitly constrained — adjust expectation
+            // based on actual Hyper behavior)
+            val info = getColumnInfo(connection, "col_bool");
+            assertThat(info).isNotNull();
+            // Verify the nullable field is present and is a valid value
+            int nullable = (int) info.get("NULLABLE");
+            assertThat(nullable)
+                    .as("Nullable should be a valid JDBC nullable constant")
+                    .isIn(
+                            DatabaseMetaData.columnNullable,
+                            DatabaseMetaData.columnNoNulls,
+                            DatabaseMetaData.columnNullableUnknown);
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_withColumnNameFilter() {
+        try (val connection = getConnection()) {
+            val md = connection.getMetaData();
+            val rs = md.getColumns(null, TEST_SCHEMA, TEST_TABLE, "col_bool");
+
+            assertThat(rs.next()).as("Should find col_bool").isTrue();
+            assertThat(rs.getString("COLUMN_NAME")).isEqualTo("col_bool");
+            assertThat(rs.next()).as("Should only find one column").isFalse();
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void getColumns_ordinalPositionsAreSequential() {
+        try (val connection = getConnection()) {
+            val md = connection.getMetaData();
+            val rs = md.getColumns(null, TEST_SCHEMA, TEST_TABLE, "%");
+
+            int expectedOrdinal = 1;
+            while (rs.next()) {
+                int actual = rs.getInt("ORDINAL_POSITION");
+                assertThat(actual)
+                        .as("Ordinal position for column %s", rs.getString("COLUMN_NAME"))
+                        .isEqualTo(expectedOrdinal);
+                expectedOrdinal++;
+            }
+            assertThat(expectedOrdinal - 1).as("Total columns").isEqualTo(19);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static DataCloudConnection getConnection() throws SQLException {
+        // The -d flag creates the database and registers it in Hyper's catalog.
+        // For gRPC, we reference it by the file path Hyper uses internally.
+        return LocalHyperTestBase.getHyperQueryConnection(
+                server, new DatabaseAttachInterceptor(databasePath, "default"));
+    }
+
+    private void assertColumnType(String columnName, JDBCType expectedType) throws SQLException {
+        assertColumnTypeName(columnName, expectedType.toString());
+    }
+
+    private void assertColumnTypeName(String columnName, String expectedTypeName) throws SQLException {
+        try (val connection = getConnection()) {
+            val info = getColumnInfo(connection, columnName);
+            assertThat(info)
+                    .as("Column %s should exist", columnName)
+                    .isNotNull();
+            assertThat(info.get("TYPE_NAME"))
+                    .as("TYPE_NAME for %s", columnName)
+                    .isEqualTo(expectedTypeName);
+        }
+    }
+
+    private Map<String, Object> getColumnInfo(DataCloudConnection connection, String columnName)
+            throws SQLException {
+        val md = connection.getMetaData();
+        val rs = md.getColumns(null, TEST_SCHEMA, TEST_TABLE, columnName);
+
+        if (!rs.next()) {
+            return null;
+        }
+
+        Map<String, Object> info = new HashMap<>();
+        info.put("COLUMN_NAME", rs.getString("COLUMN_NAME"));
+        info.put("DATA_TYPE", rs.getInt("DATA_TYPE"));
+        info.put("TYPE_NAME", rs.getString("TYPE_NAME"));
+        info.put("COLUMN_SIZE", rs.getInt("COLUMN_SIZE"));
+        info.put("NULLABLE", rs.getInt("NULLABLE"));
+        info.put("ORDINAL_POSITION", rs.getInt("ORDINAL_POSITION"));
+        info.put("IS_NULLABLE", rs.getString("IS_NULLABLE"));
+        return info;
+    }
+
+    private static List<String> collectColumn(ResultSet rs, String columnName) throws SQLException {
+        List<String> values = new ArrayList<>();
+        while (rs.next()) {
+            values.add(rs.getString(columnName));
+        }
+        return values;
+    }
+
+    private static List<Map<String, Object>> collectColumnInfo(ResultSet rs) throws SQLException {
+        List<Map<String, Object>> columns = new ArrayList<>();
+        while (rs.next()) {
+            Map<String, Object> info = new HashMap<>();
+            info.put("COLUMN_NAME", rs.getString("COLUMN_NAME"));
+            info.put("DATA_TYPE", rs.getInt("DATA_TYPE"));
+            info.put("TYPE_NAME", rs.getString("TYPE_NAME"));
+            columns.add(info);
+        }
+        return columns;
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
@@ -76,6 +76,63 @@ class SyncIteratorAdapterTest {
     }
 
     @Test
+    void testInterruptWithAsyncCloseSurfacesGrpcError() throws Exception {
+        val blockingFuture = new CompletableFuture<Optional<String>>();
+        val closeCalled = new AtomicBoolean(false);
+        val iteratorStartedBlocking = new CountDownLatch(1);
+
+        // Simulate real gRPC behavior: close() does NOT synchronously complete the future.
+        // The onError callback fires asynchronously after cancellation propagates through gRPC.
+        AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
+            @Override
+            public CompletionStage<Optional<String>> next() {
+                iteratorStartedBlocking.countDown();
+                return blockingFuture;
+            }
+
+            @Override
+            public void close() {
+                closeCalled.set(true);
+                // Simulate async gRPC onError: complete the future on a different thread after a delay
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(50);
+                    } catch (InterruptedException e) {
+                        // ignore
+                    }
+                    blockingFuture.completeExceptionally(new RuntimeException("CANCELLED: call closed by client"));
+                }).start();
+            }
+        };
+
+        val adapter = new SyncIteratorAdapter<>(asyncIterator);
+        val thrownException = new java.util.concurrent.atomic.AtomicReference<Throwable>();
+
+        Thread thread = new Thread(() -> {
+            try {
+                adapter.hasNext();
+            } catch (Throwable t) {
+                thrownException.set(t);
+            }
+        });
+
+        thread.start();
+        assertThat(iteratorStartedBlocking.await(5, TimeUnit.SECONDS)).isTrue();
+
+        thread.interrupt();
+        thread.join(5000);
+        assertThat(thread.isAlive()).isFalse();
+
+        // Must not throw IllegalStateException("Unfulfilled previous future when next is requested")
+        // Instead, the gRPC cancellation error should surface
+        assertThat(closeCalled.get()).isTrue();
+        assertThat(thrownException.get())
+                .isNotNull()
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("CANCELLED");
+    }
+
+    @Test
     void testNormalIteration() {
         val values = new String[] {"a", "b", "c"};
         val index = new AtomicInteger(0);

--- a/jdbc-core/src/test/resources/hyper_with_database.yaml
+++ b/jdbc-core/src/test/resources/hyper_with_database.yaml
@@ -1,0 +1,22 @@
+listen-connection: tcp.grpc://127.0.0.1:auto
+skip-license: true
+strict-settings-mode: true
+language: en_US
+no-password: true
+grpc_persist_results: true
+log_pipelines: true
+experimental_pg_sleep: true
+# Hyper has a default of zero threads on Windows
+grpc_threads: 2
+experimental_hyper_introspection_functions: true
+log_resource_usage_mode: 0
+log_file_max_count: 32
+log_full_context_level: trace
+result_target_chunk_size: 1
+arrow_write_buffer_initial_tuple_limit: 4
+# Allows arrays and other extended types in non-temporary tables for external databases.
+experimental_data_type_persistence: true
+# Use a fixed init-user so the gRPC service role can map to the superuser regardless of OS username.
+init-user: hyper_test_admin
+# Map the gRPC role to the superuser (init-user) which has full privileges including CREATE DATABASE.
+grpc_service_roles: {"default": {"user": "hyper_test_admin", "authorizations": [ "ERROR_DETAIL_INTERNAL", "DEBUG_ACCESS", "DATABASE_HYPER_EXTERNAL"]}}

--- a/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperDatabaseSetup.java
+++ b/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperDatabaseSetup.java
@@ -1,0 +1,240 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.hyper;
+
+import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncStreamObserverIterator;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.extern.slf4j.Slf4j;
+import salesforce.cdp.hyperdb.v1.AttachedDatabase;
+import salesforce.cdp.hyperdb.v1.ExecuteQueryResponse;
+import salesforce.cdp.hyperdb.v1.HyperServiceGrpc;
+import salesforce.cdp.hyperdb.v1.OutputFormat;
+import salesforce.cdp.hyperdb.v1.QueryParam;
+
+/**
+ * Utility for setting up databases via raw gRPC, independent of the JDBC driver.
+ *
+ * <p>This can be reused from gRPC-only test scenarios that don't go through JDBC.
+ * It uses the HyperService stub directly to execute DDL statements.</p>
+ */
+@Slf4j
+public final class HyperDatabaseSetup {
+
+    private static final long STATEMENT_TIMEOUT_SECONDS = 30;
+
+    private HyperDatabaseSetup() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Executes a single SQL statement via the raw gRPC stub, consuming the full response stream.
+     *
+     * @param stub the HyperService stub to use
+     * @param sql  the SQL statement to execute
+     * @throws RuntimeException if execution fails
+     */
+    public static void executeStatement(HyperServiceGrpc.HyperServiceStub stub, String sql) {
+        QueryParam param = QueryParam.newBuilder()
+                .setQuery(sql)
+                .setOutputFormat(OutputFormat.ARROW_IPC)
+                .setTransferMode(QueryParam.TransferMode.SYNC)
+                .build();
+
+        AsyncStreamObserverIterator<QueryParam, ExecuteQueryResponse> iterator =
+                new AsyncStreamObserverIterator<>(sql, log);
+        stub.executeQuery(param, iterator.getObserver());
+
+        // Drain the response stream
+        try {
+            while (true) {
+                CompletionStage<Optional<ExecuteQueryResponse>> next = iterator.next();
+                Optional<ExecuteQueryResponse> response =
+                        next.toCompletableFuture().get(STATEMENT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                if (!response.isPresent()) {
+                    break;
+                }
+            }
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Failed to execute: " + sql, e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while executing: " + sql, e);
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Timed out executing: " + sql, e);
+        } finally {
+            iterator.close();
+        }
+    }
+
+    /**
+     * Executes multiple SQL statements sequentially via the raw gRPC stub.
+     *
+     * @param stub       the HyperService stub to use
+     * @param statements the SQL statements to execute
+     * @throws RuntimeException if any execution fails
+     */
+    public static void executeStatements(HyperServiceGrpc.HyperServiceStub stub, List<String> statements) {
+        for (String sql : statements) {
+            log.info("Executing setup statement: {}", sql);
+            executeStatement(stub, sql);
+        }
+    }
+
+    /**
+     * Creates a new Hyper database file via the raw gRPC stub.
+     *
+     * <p>The database path is created as a temp file and returned. Subsequent statements
+     * that need to operate on this database must attach it via {@link AttachedDatabase}
+     * in the {@link QueryParam} (or use {@link com.salesforce.datacloud.jdbc.interceptor.DatabaseAttachInterceptor}).</p>
+     *
+     * @param stub the HyperService stub to use (without any database attached)
+     * @return the absolute path to the created database file
+     */
+    public static String createDatabase(HyperServiceGrpc.HyperServiceStub stub) {
+        try {
+            File dbFile = Files.createTempFile("hyper_test_", ".hyper").toFile();
+            dbFile.delete(); // Hyper needs to create the file itself
+            dbFile.deleteOnExit();
+            String dbPath = dbFile.getAbsolutePath();
+            log.info("Creating database at: {}", dbPath);
+            executeStatement(stub, "CREATE DATABASE \"" + dbPath + "\"");
+            return dbPath;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create temp file for database", e);
+        }
+    }
+
+    /**
+     * Executes a single SQL statement with a database attached.
+     *
+     * @param stub         the HyperService stub to use
+     * @param databasePath the path to the attached database
+     * @param databaseAlias the alias for the database in SQL
+     * @param sql          the SQL statement to execute
+     */
+    public static void executeStatementWithDatabase(
+            HyperServiceGrpc.HyperServiceStub stub, String databasePath, String databaseAlias, String sql) {
+        QueryParam param = QueryParam.newBuilder()
+                .setQuery(sql)
+                .setOutputFormat(OutputFormat.ARROW_IPC)
+                .setTransferMode(QueryParam.TransferMode.SYNC)
+                .addDatabases(AttachedDatabase.newBuilder()
+                        .setPath(databasePath)
+                        .setAlias(databaseAlias)
+                        .build())
+                .build();
+
+        AsyncStreamObserverIterator<QueryParam, ExecuteQueryResponse> iterator =
+                new AsyncStreamObserverIterator<>(sql, log);
+        stub.executeQuery(param, iterator.getObserver());
+
+        try {
+            while (true) {
+                CompletionStage<Optional<ExecuteQueryResponse>> next = iterator.next();
+                Optional<ExecuteQueryResponse> response =
+                        next.toCompletableFuture().get(STATEMENT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                if (!response.isPresent()) {
+                    break;
+                }
+            }
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Failed to execute: " + sql, e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while executing: " + sql, e);
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Timed out executing: " + sql, e);
+        } finally {
+            iterator.close();
+        }
+    }
+
+    /**
+     * Creates a database and populates it with the all-types test table.
+     *
+     * @param stub       the HyperService stub to use
+     * @param schemaName the schema name to create inside the database
+     * @param tableName  the table name to create
+     * @return the absolute path to the created database file
+     */
+    public static String createAndPopulateDatabase(
+            HyperServiceGrpc.HyperServiceStub stub, String schemaName, String tableName) {
+        String dbPath = createDatabase(stub);
+        for (String sql : allTypesSetupStatements(schemaName, tableName)) {
+            log.info("Setup: {}", sql);
+            executeStatementWithDatabase(stub, dbPath, "default", sql);
+        }
+        return dbPath;
+    }
+
+    /**
+     * Returns DDL statements that create a schema and table covering all Hyper types
+     * relevant for metadata testing (pg_class, pg_type, pg_attribute queries).
+     *
+     * <p>The types are derived from the protocol values used in reference testing
+     * and cover the full range of types the JDBC driver maps in QueryMetadataUtil.</p>
+     *
+     * @param schemaName the schema name to create
+     * @param tableName  the table name to create
+     * @return list of DDL statements
+     */
+    public static List<String> allTypesSetupStatements(String schemaName, String tableName) {
+        String qualifiedName = schemaName + "." + tableName;
+        return Arrays.asList(
+                "CREATE SCHEMA IF NOT EXISTS " + schemaName,
+                "DROP TABLE IF EXISTS " + qualifiedName,
+                "CREATE TABLE " + qualifiedName + " ("
+                        + "col_bool             bool,"
+                        + "col_smallint         smallint,"
+                        + "col_int              int,"
+                        + "col_bigint           bigint,"
+                        + "col_double           double precision,"
+                        + "col_numeric_18_2     numeric(18,2),"
+                        + "col_text             text,"
+                        + "col_varchar_255      varchar(255),"
+                        + "col_char_1           char(1),"
+                        + "col_date             date,"
+                        + "col_time             time,"
+                        + "col_timestamp        timestamp,"
+                        + "col_timestamptz      timestamptz,"
+                        + "col_interval         interval,"
+                        + "col_json             json,"
+                        + "col_oid              oid,"
+                        + "col_int_array        int[],"
+                        + "col_text_array       text[],"
+                        + "col_nullable_int     int"
+                        + ")",
+                "INSERT INTO " + qualifiedName + " VALUES ("
+                        + "true,"              // bool
+                        + "42,"                // smallint
+                        + "100000,"            // int
+                        + "9999999999,"        // bigint
+                        + "2.718281828,"        // double precision
+                        + "1234567.89,"        // numeric(18,2)
+                        + "'hello world',"     // text
+                        + "'test varchar',"    // varchar
+                        + "'A',"               // char(1)
+                        + "'2024-01-15',"      // date
+                        + "'13:45:30',"        // time
+                        + "'2024-01-15 13:45:30'," // timestamp
+                        + "'2024-01-15 13:45:30+00'," // timestamptz
+                        + "'1 year 2 months 3 days'," // interval
+                        + "'{\"key\": \"value\"}'," // json
+                        + "12345,"             // oid
+                        + "ARRAY[1, 2, 3],"   // int[]
+                        + "ARRAY['a', 'b'],"  // text[]
+                        + "NULL"               // nullable int
+                        + ")");
+    }
+}

--- a/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerConfig.java
+++ b/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerConfig.java
@@ -4,6 +4,7 @@
  */
 package com.salesforce.datacloud.jdbc.hyper;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,13 +27,24 @@ public class HyperServerConfig {
     @JsonProperty("grpc-request-timeout")
     String grpcRequestTimeoutSeconds = "70s";
 
+    // Path to a database file that hyperd will create/attach on startup.
+    // Handled separately in toArguments() because it uses -d short flag.
+    @Builder.Default
+    @JsonIgnore
+    String databasePath = null;
+
     public List<String> toArguments() {
         val mapper = new ObjectMapper();
         val map = mapper.convertValue(this, new TypeReference<Map<String, Object>>() {});
-        return map.entrySet().stream()
+        val args = map.entrySet().stream()
                 .filter(entry -> entry.getValue() != null)
                 .map(entry -> String.format("--%s=%s", entry.getKey().replace("_", "-"), entry.getValue()))
                 .collect(Collectors.toList());
+        if (databasePath != null) {
+            args.add("-d");
+            args.add(databasePath);
+        }
+        return args;
     }
 
     public HyperServerProcess start() {

--- a/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerManager.java
+++ b/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperServerManager.java
@@ -14,7 +14,8 @@ public final class HyperServerManager {
     @AllArgsConstructor
     public enum ConfigFile {
         DEFAULT("default.yaml"),
-        SMALL_CHUNKS("hyper.yaml");
+        SMALL_CHUNKS("hyper.yaml"),
+        WITH_DATABASE("hyper_with_database.yaml");
 
         final String filename;
     }


### PR DESCRIPTION
## Bug Fix: SyncIteratorAdapter interrupt race condition

Fixed IllegalStateException('Unfulfilled previous future when next is requested') in AsyncStreamObserver.requestNext(). When a thread was interrupted during CompletableFuture.get(), the old code recursively called hasNext() which created a second pendingFuture before gRPC's async onError resolved the first one.

Fix: Hoist the CompletableFuture out of the while loop so on interrupt we close() then re-wait on the *same* future. The real gRPC cancellation error propagates naturally.

## Bug Fixes: DatabaseMetaData JDBC spec violations

Fixed multiple JDBC specification violations in DataCloudDatabaseMetadata:

### Illegal null returns (NullPointerException risk) Methods that returned null where the JDBC spec requires a non-null String. Clients calling .split(), .length(), etc. on these would crash:
- getNumericFunctions() -> was null, now returns empty string
- getStringFunctions() -> was null, now returns empty string
- getSystemFunctions() -> was null, now returns empty string
- getTimeDateFunctions() -> was null, now returns empty string
- getExtraNameCharacters() -> was null, now returns empty string

### Illegal null ResultSet returns (NullPointerException risk) Methods that returned null instead of throwing SQLFeatureNotSupportedException. Clients iterating results would NPE instead of getting a proper exception:
- getProcedures() -> was null, now throws SQLFeatureNotSupportedException
- getProcedureColumns() -> was null, now throws SQLFeatureNotSupportedException
- getUDTs() -> was null, now throws SQLFeatureNotSupportedException
- getSuperTypes() -> was null, now throws SQLFeatureNotSupportedException
- getSuperTables() -> was null, now throws SQLFeatureNotSupportedException
- getAttributes() -> was null, now throws SQLFeatureNotSupportedException
- getClientInfoProperties() -> was null, now throws SQLFeatureNotSupportedException
- getFunctions() -> was null, now throws SQLFeatureNotSupportedException
- getFunctionColumns() -> was null, now throws SQLFeatureNotSupportedException
- getPseudoColumns() -> was null, now throws SQLFeatureNotSupportedException

### Wrong return values
- nullPlusNonNullIsNull() -> was false, now true (SQL standard: NULL + x = NULL)
- supportsANSI92IntermediateSQL() -> was true, now false (requires dynamic SQL which Hyper does not expose in the gRPC protocol)
- supportsANSI92FullSQL() -> was true, now false (requires assertions, domain definitions, etc.)
- getDefaultTransactionIsolation() -> was TRANSACTION_SERIALIZABLE, now TRANSACTION_NONE (Hyper does not support transactions)
- getResultSetHoldability() -> was 0, now HOLD_CURSORS_OVER_COMMIT
- getJDBCMajorVersion() -> was 1, now 4 (we implement JDBC 4.x)
- getSQLStateType() -> was 0, now sqlStateSQL (Hyper uses SQL standard states)

## Metadata Integration Tests (NEW)

Added 28 end-to-end integration tests for DatabaseMetaData.getTables(), getColumns(), getSchemas() against a real local Hyper instance. Database is created via raw gRPC (JDBC-independent) and populated with a table covering 19 columns across all supported types.

New infrastructure:
- DatabaseAttachInterceptor: gRPC ClientInterceptor for attaching databases. In interceptor package alongside AuthorizationHeaderInterceptor.
- HyperDatabaseSetup: Raw gRPC utility for database creation/population.
- hyper_with_database.yaml: Hyper config with DATABASE_HYPER_EXTERNAL, superuser mapping, and experimental_data_type_persistence for arrays.

Types covered: bool, smallint, int, bigint, double precision, numeric(18,2), text, varchar(255), char(1), date, time, timestamp, timestamptz, interval, json, oid, int[], text[]

## Known Issues (TODO)

### QueryMetadataUtil.dbTypeToSql mapping gaps
Integration tests revealed that Hyper's format_type() returns long-form type names not in dbTypeToSql. This causes DATA_TYPE to use raw OIDs instead of standard java.sql.Types values, breaking JDBC clients:
  - 'smallint' -> OID 21, should be Types.SMALLINT (5)
  - 'integer' -> OID 23, should be Types.INTEGER (4)
  - 'bigint' -> OID 20, should be Types.BIGINT (-5)
  - 'double precision' -> OID 701, should be Types.DOUBLE (8)
  - 'character varying(N)' -> OID, should be Types.VARCHAR (12)
  - 'character(N)' -> OID, should be Types.CHAR (1)
  - 'array(T)' -> OID, should be Types.ARRAY (2003)

### External database type limitations
hyper.external: does not support: float32, bytea, numeric(38,18)/128-bit. experimental_data_type_persistence unlocks arrays. These match production (lakehouse/Iceberg) limitations.