### PR TITLE
fix: async interrupt race condition in SyncIteratorAdapter

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
@@ -8,6 +8,7 @@ import com.salesforce.datacloud.jdbc.protocol.CloseableIterator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
@@ -61,25 +62,26 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
             return nextValue.isPresent();
         }
 
-        // Block waiting for next value
+        // Block waiting for next value. The future is hoisted out of the loop so that on interrupt
+        // we close the iterator (triggering gRPC cancellation) and then re-wait on the *same* future
+        // rather than requesting a new one (which would hit "Unfulfilled previous future").
         boolean interrupted = false;
+        CompletableFuture<Optional<T>> future =
+                asyncIterator.next().toCompletableFuture();
         try {
             while (true) {
                 try {
-                    nextValue = asyncIterator.next().toCompletableFuture().get();
+                    nextValue = future.get();
                     if (!nextValue.isPresent()) {
                         done = true;
                     }
                     return nextValue.isPresent();
                 } catch (InterruptedException ie) {
                     interrupted = true;
-                    // This will cause the ongoing call to be stopped and thus the future will get an error element
-                    // which will cause the while loop to exit.
                     try {
                         asyncIterator.close();
                     } catch (Exception ignore) {
                     }
-                    return hasNext();
                 } catch (ExecutionException ee) {
                     Throwable cause = ee.getCause();
                     if (cause instanceof RuntimeException) {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
@@ -66,8 +66,7 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
         // we close the iterator (triggering gRPC cancellation) and then re-wait on the *same* future
         // rather than requesting a new one (which would hit "Unfulfilled previous future").
         boolean interrupted = false;
-        CompletableFuture<Optional<T>> future =
-                asyncIterator.next().toCompletableFuture();
+        CompletableFuture<Optional<T>> future = asyncIterator.next().toCompletableFuture();
         try {
             while (true) {
                 try {
@@ -82,14 +81,11 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
                         asyncIterator.close();
                     } catch (Exception ignore) {
                     }
-                } catch (ExecutionException ee) {
+                } catch (ExecutionException | CompletionException ee) {
+                    // The async stream is permanently dead after an error; mark done so that any
+                    // retry on hasNext() returns false instead of requesting a new future.
+                    done = true;
                     Throwable cause = ee.getCause();
-                    if (cause instanceof RuntimeException) {
-                        throw (RuntimeException) cause;
-                    }
-                    throw new RuntimeException(cause);
-                } catch (CompletionException ce) {
-                    Throwable cause = ce.getCause();
                     if (cause instanceof RuntimeException) {
                         throw (RuntimeException) cause;
                     }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
@@ -32,6 +32,8 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
     private Optional<T> nextValue;
     /** Whether iteration has completed (either naturally or due to interruption). */
     private boolean done;
+    /** Terminal error from a previous call, re-thrown on subsequent invocations. */
+    private RuntimeException terminalError;
 
     /**
      * Creates a new sync adapter wrapping the given async iterator.
@@ -55,6 +57,9 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
      */
     @Override
     public boolean hasNext() {
+        if (terminalError != null) {
+            throw terminalError;
+        }
         if (done) {
             return false;
         }
@@ -82,14 +87,14 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
                     } catch (Exception ignore) {
                     }
                 } catch (ExecutionException | CompletionException ee) {
-                    // The async stream is permanently dead after an error; mark done so that any
-                    // retry on hasNext() returns false instead of requesting a new future.
-                    done = true;
+                    // The async stream is permanently dead after an error. Cache the exception so a
+                    // retried hasNext() re-surfaces it instead of requesting a new future (which
+                    // would hit "Unfulfilled previous future" or mask the original error).
                     Throwable cause = ee.getCause();
-                    if (cause instanceof RuntimeException) {
-                        throw (RuntimeException) cause;
-                    }
-                    throw new RuntimeException(cause);
+                    terminalError = (cause instanceof RuntimeException)
+                            ? (RuntimeException) cause
+                            : new RuntimeException(cause);
+                    throw terminalError;
                 }
             }
         } finally {

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
@@ -135,7 +135,7 @@ class SyncIteratorAdapterTest {
     }
 
     @Test
-    void testHasNextAfterErrorReturnsFalseWithoutRequestingNewFuture() {
+    void testHasNextAfterErrorRethrowsWithoutRequestingNewFuture() {
         val nextCallCount = new AtomicInteger(0);
         AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
             @Override
@@ -156,8 +156,12 @@ class SyncIteratorAdapterTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("stream error");
 
-        // After a terminal error, hasNext() must return false without re-driving the iterator.
-        assertThat(adapter.hasNext()).isFalse();
+        // Subsequent calls must re-surface the same error without re-driving the iterator. This
+        // preserves the original error for callers that probe the stream twice (e.g. execute()
+        // followed by getResultSet()) instead of masking it as an empty stream.
+        assertThatThrownBy(adapter::hasNext)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("stream error");
         assertThat(nextCallCount.get()).isEqualTo(1);
     }
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
@@ -76,6 +76,63 @@ class SyncIteratorAdapterTest {
     }
 
     @Test
+    void testInterruptWithAsyncCloseSurfacesGrpcError() throws Exception {
+        val blockingFuture = new CompletableFuture<Optional<String>>();
+        val closeCalled = new AtomicBoolean(false);
+        val iteratorStartedBlocking = new CountDownLatch(1);
+
+        // Simulate real gRPC behavior: close() does NOT synchronously complete the future.
+        // The onError callback fires asynchronously after cancellation propagates through gRPC.
+        AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
+            @Override
+            public CompletionStage<Optional<String>> next() {
+                iteratorStartedBlocking.countDown();
+                return blockingFuture;
+            }
+
+            @Override
+            public void close() {
+                closeCalled.set(true);
+                // Simulate async gRPC onError: complete the future on a different thread after a delay
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(50);
+                    } catch (InterruptedException e) {
+                        // ignore
+                    }
+                    blockingFuture.completeExceptionally(new RuntimeException("CANCELLED: call closed by client"));
+                }).start();
+            }
+        };
+
+        val adapter = new SyncIteratorAdapter<>(asyncIterator);
+        val thrownException = new java.util.concurrent.atomic.AtomicReference<Throwable>();
+
+        Thread thread = new Thread(() -> {
+            try {
+                adapter.hasNext();
+            } catch (Throwable t) {
+                thrownException.set(t);
+            }
+        });
+
+        thread.start();
+        assertThat(iteratorStartedBlocking.await(5, TimeUnit.SECONDS)).isTrue();
+
+        thread.interrupt();
+        thread.join(5000);
+        assertThat(thread.isAlive()).isFalse();
+
+        // Must not throw IllegalStateException("Unfulfilled previous future when next is requested")
+        // Instead, the gRPC cancellation error should surface
+        assertThat(closeCalled.get()).isTrue();
+        assertThat(thrownException.get())
+                .isNotNull()
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("CANCELLED");
+    }
+
+    @Test
     void testNormalIteration() {
         val values = new String[] {"a", "b", "c"};
         val index = new AtomicInteger(0);

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
@@ -95,13 +95,15 @@ class SyncIteratorAdapterTest {
                 closeCalled.set(true);
                 // Simulate async gRPC onError: complete the future on a different thread after a delay
                 new Thread(() -> {
-                    try {
-                        Thread.sleep(50);
-                    } catch (InterruptedException e) {
-                        // ignore
-                    }
-                    blockingFuture.completeExceptionally(new RuntimeException("CANCELLED: call closed by client"));
-                }).start();
+                            try {
+                                Thread.sleep(50);
+                            } catch (InterruptedException e) {
+                                // ignore
+                            }
+                            blockingFuture.completeExceptionally(
+                                    new RuntimeException("CANCELLED: call closed by client"));
+                        })
+                        .start();
             }
         };
 
@@ -130,6 +132,33 @@ class SyncIteratorAdapterTest {
                 .isNotNull()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("CANCELLED");
+    }
+
+    @Test
+    void testHasNextAfterErrorReturnsFalseWithoutRequestingNewFuture() {
+        val nextCallCount = new AtomicInteger(0);
+        AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
+            @Override
+            public CompletionStage<Optional<String>> next() {
+                nextCallCount.incrementAndGet();
+                val failed = new CompletableFuture<Optional<String>>();
+                failed.completeExceptionally(new RuntimeException("stream error"));
+                return failed;
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        val adapter = new SyncIteratorAdapter<>(asyncIterator);
+
+        assertThatThrownBy(adapter::hasNext)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("stream error");
+
+        // After a terminal error, hasNext() must return false without re-driving the iterator.
+        assertThat(adapter.hasNext()).isFalse();
+        assertThat(nextCallCount.get()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
Fixes IllegalStateException("Unfulfilled previous future when next is requested") thrown from AsyncStreamObserver.requestNext() when a thread is interrupted while blocked on a gRPC response.

Root cause: the old interrupt handler recursively called hasNext(), which requested a *new* future from the async iterator before gRPC's async onError callback had resolved the *previous* pendingFuture.

Fix: hoist the CompletableFuture out of the while loop so that on interrupt we close() the iterator (triggering gRPC cancellation) and then re-wait on the *same* future. The real gRPC CANCELLED error then propagates naturally through the ExecutionException path.

Adds a regression test that simulates real gRPC behavior (close() does not synchronously complete the future) and asserts the cancellation error surfaces instead of the IllegalStateException.