### PR TITLE
fix: JDBC spec compliance and small metadata bug fixes

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadata.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadata.java
@@ -20,6 +20,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -181,34 +182,41 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
         return getSqlKeywords();
     }
 
+    // Used by JDBC clients to discover which scalar numeric functions (e.g. ABS, CEIL) can be used in SQL escape syntax {fn ...}
     @Override
     public String getNumericFunctions() {
-        return null;
+        return "";
     }
 
+    // Used by JDBC clients to discover which scalar string functions (e.g. CONCAT, SUBSTRING) can be used in SQL escape syntax {fn ...}
     @Override
     public String getStringFunctions() {
-        return null;
+        return "";
     }
 
+    // Used by JDBC clients to discover which system functions (e.g. USER, IFNULL) can be used in SQL escape syntax {fn ...}
     @Override
     public String getSystemFunctions() {
-        return null;
+        return "";
     }
 
+    // Used by JDBC clients to discover which time/date functions (e.g. NOW, CURDATE) can be used in SQL escape syntax {fn ...}
     @Override
     public String getTimeDateFunctions() {
-        return null;
+        return "";
     }
 
+    // Used by JDBC clients to escape wildcard characters in DatabaseMetaData search patterns (e.g. getTables, getColumns)
     @Override
     public String getSearchStringEscape() {
         return "\\";
     }
 
+    // Used by JDBC clients to discover which non-alphanumeric characters can appear in unquoted identifier names
+    // is empty to keep it simple for now, too much quoting shouldn't be an issue
     @Override
     public String getExtraNameCharacters() {
-        return null;
+        return "";
     }
 
     @Override
@@ -228,7 +236,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public boolean nullPlusNonNullIsNull() {
-        return false;
+        return true;
     }
 
     @Override
@@ -326,14 +334,16 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
         return true;
     }
 
+    // Intermediate level requires features like dynamic SQL that Hyper does not expose in gRPC protocol
     @Override
     public boolean supportsANSI92IntermediateSQL() {
-        return true;
+        return false;
     }
 
+    // Full level additionally requires assertions, temporary tables with preserve semantics, and domain definitions
     @Override
     public boolean supportsANSI92FullSQL() {
-        return true;
+        return false;
     }
 
     @Override
@@ -613,7 +623,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getDefaultTransactionIsolation() {
-        return Connection.TRANSACTION_SERIALIZABLE;
+        return Connection.TRANSACTION_NONE;
     }
 
     @Override
@@ -647,14 +657,16 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern) {
-        return null;
+    public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getProcedures is not supported");
     }
 
     @Override
     public ResultSet getProcedureColumns(
-            String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern) {
-        return null;
+            String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getProcedureColumns is not supported");
     }
 
     @Override
@@ -806,8 +818,9 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types) {
-        return null;
+    public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getUDTs is not supported");
     }
 
     @Override
@@ -831,19 +844,20 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) {
-        return null;
+    public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) throws SQLException {
+        throw new SQLFeatureNotSupportedException("getSuperTypes is not supported");
     }
 
     @Override
-    public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) {
-        return null;
+    public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
+        throw new SQLFeatureNotSupportedException("getSuperTables is not supported");
     }
 
     @Override
     public ResultSet getAttributes(
-            String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern) {
-        return null;
+            String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getAttributes is not supported");
     }
 
     @Override
@@ -853,7 +867,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getResultSetHoldability() {
-        return 0;
+        return ResultSet.HOLD_CURSORS_OVER_COMMIT;
     }
 
     @Override
@@ -868,7 +882,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getJDBCMajorVersion() {
-        return 1;
+        return 4;
     }
 
     @Override
@@ -878,7 +892,7 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getSQLStateType() {
-        return 0;
+        return DatabaseMetaData.sqlStateSQL;
     }
 
     @Override
@@ -912,25 +926,28 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public ResultSet getClientInfoProperties() {
-        return null;
+    public ResultSet getClientInfoProperties() throws SQLException {
+        throw new SQLFeatureNotSupportedException("getClientInfoProperties is not supported");
     }
 
     @Override
-    public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern) {
-        return null;
+    public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getFunctions is not supported");
     }
 
     @Override
     public ResultSet getFunctionColumns(
-            String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern) {
-        return null;
+            String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getFunctionColumns is not supported");
     }
 
     @Override
     public ResultSet getPseudoColumns(
-            String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) {
-        return null;
+            String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException("getPseudoColumns is not supported");
     }
 
     @Override

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadata.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadata.java
@@ -182,31 +182,36 @@ public class DataCloudDatabaseMetadata implements DatabaseMetaData {
         return getSqlKeywords();
     }
 
-    // Used by JDBC clients to discover which scalar numeric functions (e.g. ABS, CEIL) can be used in SQL escape syntax {fn ...}
+    // Used by JDBC clients to discover which scalar numeric functions (e.g. ABS, CEIL) can be used in SQL escape syntax
+    // {fn ...}
     @Override
     public String getNumericFunctions() {
         return "";
     }
 
-    // Used by JDBC clients to discover which scalar string functions (e.g. CONCAT, SUBSTRING) can be used in SQL escape syntax {fn ...}
+    // Used by JDBC clients to discover which scalar string functions (e.g. CONCAT, SUBSTRING) can be used in SQL escape
+    // syntax {fn ...}
     @Override
     public String getStringFunctions() {
         return "";
     }
 
-    // Used by JDBC clients to discover which system functions (e.g. USER, IFNULL) can be used in SQL escape syntax {fn ...}
+    // Used by JDBC clients to discover which system functions (e.g. USER, IFNULL) can be used in SQL escape syntax {fn
+    // ...}
     @Override
     public String getSystemFunctions() {
         return "";
     }
 
-    // Used by JDBC clients to discover which time/date functions (e.g. NOW, CURDATE) can be used in SQL escape syntax {fn ...}
+    // Used by JDBC clients to discover which time/date functions (e.g. NOW, CURDATE) can be used in SQL escape syntax
+    // {fn ...}
     @Override
     public String getTimeDateFunctions() {
         return "";
     }
 
-    // Used by JDBC clients to escape wildcard characters in DatabaseMetaData search patterns (e.g. getTables, getColumns)
+    // Used by JDBC clients to escape wildcard characters in DatabaseMetaData search patterns (e.g. getTables,
+    // getColumns)
     @Override
     public String getSearchStringEscape() {
         return "\\";

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/QueryMetadataUtil.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/QueryMetadataUtil.java
@@ -214,7 +214,8 @@ final class QueryMetadataUtil {
             int columnSize = 255;
             rowData[COLUMN_SIZE_INDEX] = columnSize;
 
-            int decimalDigits = 2;
+            String resolvedTypeName = (String) rowData[TYPE_NAME_INDEX];
+            int decimalDigits = isDecimalType(resolvedTypeName) ? 2 : 0;
             rowData[DECIMAL_DIGITS_INDEX] = decimalDigits;
 
             int numPrecRadix = 10;
@@ -233,10 +234,9 @@ final class QueryMetadataUtil {
 
             rowData[SQL_DATA_TYPE_INDEX] = null;
 
-            String sqlDateTimeSub = StringUtils.EMPTY;
-            rowData[SQL_DATE_TIME_SUB_INDEX] = sqlDateTimeSub;
+            rowData[SQL_DATE_TIME_SUB_INDEX] = null;
 
-            int charOctetLength = 2;
+            Integer charOctetLength = isCharType(resolvedTypeName) ? columnSize : null;
             rowData[CHAR_OCTET_LENGTH_INDEX] = charOctetLength;
 
             int ordinalPosition = resultSet.getInt("attnum");
@@ -445,6 +445,18 @@ final class QueryMetadataUtil {
             immutableEntry(
                     "MATERIALIZED VIEW",
                     ImmutableMap.of("SCHEMAS", "c.relkind = 'm'", "NOSCHEMAS", "c.relkind = 'm'")));
+
+    private static boolean isDecimalType(String typeName) {
+        return JDBCType.NUMERIC.toString().equals(typeName)
+                || JDBCType.DECIMAL.toString().equals(typeName)
+                || JDBCType.REAL.toString().equals(typeName)
+                || JDBCType.DOUBLE.toString().equals(typeName);
+    }
+
+    private static boolean isCharType(String typeName) {
+        return JDBCType.VARCHAR.toString().equals(typeName)
+                || JDBCType.CHAR.toString().equals(typeName);
+    }
 
     public static String quoteStringLiteral(String v) {
         StringBuilder result = new StringBuilder();

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/metadata/ColumnType.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/metadata/ColumnType.java
@@ -267,14 +267,18 @@ public class ColumnType {
         switch (type) {
             case BOOLEAN:
                 return Boolean.class;
+            case TINYINT:
+                return Short.class;
             case SMALLINT:
             case INTEGER:
                 return Integer.class;
             case BIGINT:
                 return Long.class;
+            case DECIMAL:
             case NUMERIC:
                 return BigDecimal.class;
             case FLOAT:
+            case REAL:
                 return Float.class;
             case DOUBLE:
                 return Double.class;
@@ -282,6 +286,7 @@ public class ColumnType {
             case VARCHAR:
                 return String.class;
             case BINARY:
+            case VARBINARY:
                 return byte[].class;
             case DATE:
                 return Date.class;
@@ -293,6 +298,8 @@ public class ColumnType {
                 return Timestamp.class;
             case ARRAY:
                 return Array.class;
+            case NULL:
+                return Object.class;
         }
         throw new IllegalArgumentException("Unsupported type: " + type);
     }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/resultset/SimpleResultSet.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/resultset/SimpleResultSet.java
@@ -169,6 +169,7 @@ public abstract class SimpleResultSet<SELF>
     @Override
     public long getLong(int columnIndex) throws SQLException {
         switch (metadata.getColumn(columnIndex).getType().getType()) {
+            case TINYINT:
             case SMALLINT:
             case INTEGER:
             case BIGINT: {
@@ -188,7 +189,10 @@ public abstract class SimpleResultSet<SELF>
     @Override
     public float getFloat(int columnIndex) throws SQLException {
         double v = getDouble(columnIndex);
-        if (v < Float.MIN_VALUE || v > Float.MAX_VALUE) {
+        if (wasNull) {
+            return 0;
+        }
+        if (v < -Float.MAX_VALUE || v > Float.MAX_VALUE) {
             throw new SQLException(
                     "Column " + getMetaData().getColumnName(columnIndex) + " is out of range for a float");
         }
@@ -198,6 +202,7 @@ public abstract class SimpleResultSet<SELF>
     @Override
     public double getDouble(int columnIndex) throws SQLException {
         switch (metadata.getColumn(columnIndex).getType().getType()) {
+            case TINYINT:
             case SMALLINT:
             case INTEGER:
             case BIGINT: {
@@ -214,6 +219,7 @@ public abstract class SimpleResultSet<SELF>
     @Override
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
         switch (metadata.getColumn(columnIndex).getType().getType()) {
+            case TINYINT:
             case SMALLINT:
             case INTEGER:
             case BIGINT: {

--- a/jdbc-core/src/main/resources/sql/get_schemas_query.sql
+++ b/jdbc-core/src/main/resources/sql/get_schemas_query.sql
@@ -5,5 +5,5 @@ WHERE nspname <> 'pg_toast'
                OR nspname = (pg_catalog.current_schemas(true))[1])
   AND (nspname !~ '^pg_toast_temp_'
                OR nspname = replace((pg_catalog.current_schemas(true))[1], 'pg_temp_', 'pg_toast_temp_'))
-  AND (nspname !~ 'tableau*')
-  AND (nspname !~ 'pg_*')
+  AND (nspname !~ '^tableau')
+  AND (nspname !~ '^pg_')

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadataTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudDatabaseMetadataTest.java
@@ -18,6 +18,7 @@ import com.salesforce.datacloud.jdbc.util.JdbcURL;
 import com.salesforce.datacloud.jdbc.util.ThrowingJdbcSupplier;
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -233,22 +234,22 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testGetNumericFunctions() {
-        assertThat(dataCloudDatabaseMetadata.getNumericFunctions()).isNull();
+        assertThat(dataCloudDatabaseMetadata.getNumericFunctions()).isEqualTo("");
     }
 
     @Test
     public void testGetStringFunctions() {
-        assertThat(dataCloudDatabaseMetadata.getStringFunctions()).isNull();
+        assertThat(dataCloudDatabaseMetadata.getStringFunctions()).isEqualTo("");
     }
 
     @Test
     public void testGetSystemFunctions() {
-        assertThat(dataCloudDatabaseMetadata.getSystemFunctions()).isNull();
+        assertThat(dataCloudDatabaseMetadata.getSystemFunctions()).isEqualTo("");
     }
 
     @Test
     public void testGetTimeDateFunctions() {
-        assertThat(dataCloudDatabaseMetadata.getTimeDateFunctions()).isNull();
+        assertThat(dataCloudDatabaseMetadata.getTimeDateFunctions()).isEqualTo("");
     }
 
     @Test
@@ -258,7 +259,7 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testGetExtraNameCharacters() {
-        assertThat(dataCloudDatabaseMetadata.getExtraNameCharacters()).isNull();
+        assertThat(dataCloudDatabaseMetadata.getExtraNameCharacters()).isEqualTo("");
     }
 
     @Test
@@ -278,7 +279,7 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testNullPlusNonNullIsNull() {
-        assertThat(dataCloudDatabaseMetadata.nullPlusNonNullIsNull()).isFalse();
+        assertThat(dataCloudDatabaseMetadata.nullPlusNonNullIsNull()).isTrue();
     }
 
     @Test
@@ -369,12 +370,12 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testSupportsANSI92IntermediateSQL() {
-        assertThat(dataCloudDatabaseMetadata.supportsANSI92IntermediateSQL()).isTrue();
+        assertThat(dataCloudDatabaseMetadata.supportsANSI92IntermediateSQL()).isFalse();
     }
 
     @Test
     public void testSupportsANSI92FullSQL() {
-        assertThat(dataCloudDatabaseMetadata.supportsANSI92FullSQL()).isTrue();
+        assertThat(dataCloudDatabaseMetadata.supportsANSI92FullSQL()).isFalse();
     }
 
     @Test
@@ -666,8 +667,7 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testGetDefaultTransactionIsolation() {
-        assertThat(dataCloudDatabaseMetadata.getDefaultTransactionIsolation())
-                .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
+        assertThat(dataCloudDatabaseMetadata.getDefaultTransactionIsolation()).isEqualTo(Connection.TRANSACTION_NONE);
     }
 
     @Test
@@ -707,15 +707,16 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testGetProcedures() {
-        assertThat(dataCloudDatabaseMetadata.getProcedures(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
-                .isNull();
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getProcedures(
+                        StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
     public void testGetProcedureColumns() {
-        assertThat(dataCloudDatabaseMetadata.getProcedureColumns(
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getProcedureColumns(
                         StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
-                .isNull();
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
@@ -1292,10 +1293,11 @@ public class DataCloudDatabaseMetadataTest {
     }
 
     @Test
+    @SneakyThrows
     public void testGetUDTs() {
-        assertThat(dataCloudDatabaseMetadata.getUDTs(
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getUDTs(
                         StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, new int[] {}))
-                .isNull();
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
@@ -1324,22 +1326,27 @@ public class DataCloudDatabaseMetadataTest {
     }
 
     @Test
+    @SneakyThrows
     public void testGetSuperTypes() {
-        assertThat(dataCloudDatabaseMetadata.getSuperTypes(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
-                .isNull();
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getSuperTypes(
+                        StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
+    @SneakyThrows
     public void testGetSuperTables() {
-        assertThat(dataCloudDatabaseMetadata.getSuperTables(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
-                .isNull();
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getSuperTables(
+                        StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
+    @SneakyThrows
     public void testGetAttributes() {
-        assertThat(dataCloudDatabaseMetadata.getAttributes(
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getAttributes(
                         StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
-                .isNull();
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
@@ -1349,7 +1356,7 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testGetResultSetHoldability() {
-        assertThat(dataCloudDatabaseMetadata.getResultSetHoldability()).isEqualTo(0);
+        assertThat(dataCloudDatabaseMetadata.getResultSetHoldability()).isEqualTo(ResultSet.HOLD_CURSORS_OVER_COMMIT);
     }
 
     @Test
@@ -1364,7 +1371,7 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testGetJDBCMajorVersion() {
-        assertThat(dataCloudDatabaseMetadata.getJDBCMajorVersion()).isEqualTo(1);
+        assertThat(dataCloudDatabaseMetadata.getJDBCMajorVersion()).isEqualTo(4);
     }
 
     @Test
@@ -1374,7 +1381,7 @@ public class DataCloudDatabaseMetadataTest {
 
     @Test
     public void testGetSQLStateType() {
-        assertThat(dataCloudDatabaseMetadata.getSQLStateType()).isEqualTo(0);
+        assertThat(dataCloudDatabaseMetadata.getSQLStateType()).isEqualTo(DatabaseMetaData.sqlStateSQL);
     }
 
     @Test
@@ -1497,28 +1504,34 @@ public class DataCloudDatabaseMetadataTest {
     }
 
     @Test
+    @SneakyThrows
     public void testGetClientInfoProperties() {
-        assertThat(dataCloudDatabaseMetadata.getClientInfoProperties()).isNull();
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getClientInfoProperties())
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
+    @SneakyThrows
     public void testGetFunctions() {
-        assertThat(dataCloudDatabaseMetadata.getFunctions(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
-                .isNull();
+        assertThatThrownBy(() ->
+                        dataCloudDatabaseMetadata.getFunctions(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
+    @SneakyThrows
     public void testGetFunctionColumns() {
-        assertThat(dataCloudDatabaseMetadata.getFunctionColumns(
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getFunctionColumns(
                         StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
-                .isNull();
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test
+    @SneakyThrows
     public void testGetPseudoColumns() {
-        assertThat(dataCloudDatabaseMetadata.getPseudoColumns(
+        assertThatThrownBy(() -> dataCloudDatabaseMetadata.getPseudoColumns(
                         StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))
-                .isNull();
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
     }
 
     @Test

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/MetadataResultSetTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/MetadataResultSetTest.java
@@ -150,6 +150,58 @@ public class MetadataResultSetTest {
 
     @Test
     @SneakyThrows
+    public void testGetColumnsDecimalDigitsAndCharOctetLength() {
+        assertWithConnection(connection -> {
+            val metaData = connection.getMetaData();
+            try (val columns = metaData.getColumns(null, null, null, null)) {
+                while (columns.next()) {
+                    val typeName = columns.getString("TYPE_NAME");
+                    val decimalDigits = columns.getInt("DECIMAL_DIGITS");
+                    val charOctetLength = columns.getString("CHAR_OCTET_LENGTH");
+                    val sqlDateTimeSub = columns.getString("SQL_DATETIME_SUB");
+
+                    assertThat(sqlDateTimeSub)
+                            .as("SQL_DATETIME_SUB should be null")
+                            .isNull();
+
+                    if ("VARCHAR".equals(typeName) || "CHAR".equals(typeName)) {
+                        assertThat(charOctetLength)
+                                .as("CHAR_OCTET_LENGTH for %s", typeName)
+                                .isNotNull();
+                    } else if ("INTEGER".equals(typeName) || "BIGINT".equals(typeName) || "BOOLEAN".equals(typeName)) {
+                        assertThat(charOctetLength)
+                                .as("CHAR_OCTET_LENGTH for non-char type %s", typeName)
+                                .isNull();
+                        assertThat(decimalDigits)
+                                .as("DECIMAL_DIGITS for integer type %s", typeName)
+                                .isEqualTo(0);
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    public void testGetSchemasFiltersOutSystemSchemas() {
+        assertWithConnection(connection -> {
+            val metaData = connection.getMetaData();
+            try (val schemas = metaData.getSchemas()) {
+                while (schemas.next()) {
+                    val schemaName = schemas.getString("TABLE_SCHEM");
+                    assertThat(schemaName)
+                            .as("Should not return pg_ prefixed schemas")
+                            .doesNotStartWith("pg_");
+                    assertThat(schemaName)
+                            .as("Should not return tableau prefixed schemas")
+                            .doesNotStartWith("tableau");
+                }
+            }
+        });
+    }
+
+    @Test
+    @SneakyThrows
     @Disabled
     public void testMetadataResultSetColumnLookup() {
         // Test MetadataResultSet column lookup through DatabaseMetaData

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/metadata/ColumnTypeTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/metadata/ColumnTypeTest.java
@@ -1,0 +1,189 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.core.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Date;
+import java.sql.JDBCType;
+import java.sql.Time;
+import java.sql.Timestamp;
+import org.junit.jupiter.api.Test;
+
+class ColumnTypeTest {
+
+    @Test
+    void getJavaTypeForBooleanReturnsBoolean() {
+        assertThat(new ColumnType(JDBCType.BOOLEAN, true).getJavaType()).isEqualTo(Boolean.class);
+    }
+
+    @Test
+    void getJavaTypeForTinyintReturnsShort() {
+        assertThat(new ColumnType(JDBCType.TINYINT, true).getJavaType()).isEqualTo(Short.class);
+    }
+
+    @Test
+    void getJavaTypeForSmallintReturnsInteger() {
+        assertThat(new ColumnType(JDBCType.SMALLINT, true).getJavaType()).isEqualTo(Integer.class);
+    }
+
+    @Test
+    void getJavaTypeForIntegerReturnsInteger() {
+        assertThat(new ColumnType(JDBCType.INTEGER, true).getJavaType()).isEqualTo(Integer.class);
+    }
+
+    @Test
+    void getJavaTypeForBigintReturnsLong() {
+        assertThat(new ColumnType(JDBCType.BIGINT, true).getJavaType()).isEqualTo(Long.class);
+    }
+
+    @Test
+    void getJavaTypeForDecimalReturnsBigDecimal() {
+        assertThat(new ColumnType(JDBCType.DECIMAL, 10, 2, true).getJavaType()).isEqualTo(BigDecimal.class);
+    }
+
+    @Test
+    void getJavaTypeForNumericReturnsBigDecimal() {
+        assertThat(new ColumnType(JDBCType.NUMERIC, 10, 2, true).getJavaType()).isEqualTo(BigDecimal.class);
+    }
+
+    @Test
+    void getJavaTypeForFloatReturnsFloat() {
+        assertThat(new ColumnType(JDBCType.FLOAT, true).getJavaType()).isEqualTo(Float.class);
+    }
+
+    @Test
+    void getJavaTypeForRealReturnsFloat() {
+        assertThat(new ColumnType(JDBCType.REAL, true).getJavaType()).isEqualTo(Float.class);
+    }
+
+    @Test
+    void getJavaTypeForDoubleReturnsDouble() {
+        assertThat(new ColumnType(JDBCType.DOUBLE, true).getJavaType()).isEqualTo(Double.class);
+    }
+
+    @Test
+    void getJavaTypeForCharReturnsString() {
+        assertThat(new ColumnType(JDBCType.CHAR, 10, 0, true).getJavaType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void getJavaTypeForVarcharReturnsString() {
+        assertThat(new ColumnType(JDBCType.VARCHAR, 255, 0, true).getJavaType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void getJavaTypeForBinaryReturnsByteArray() {
+        assertThat(new ColumnType(JDBCType.BINARY, true).getJavaType()).isEqualTo(byte[].class);
+    }
+
+    @Test
+    void getJavaTypeForVarbinaryReturnsByteArray() {
+        assertThat(new ColumnType(JDBCType.VARBINARY, true).getJavaType()).isEqualTo(byte[].class);
+    }
+
+    @Test
+    void getJavaTypeForDateReturnsDate() {
+        assertThat(new ColumnType(JDBCType.DATE, true).getJavaType()).isEqualTo(Date.class);
+    }
+
+    @Test
+    void getJavaTypeForTimeReturnsTime() {
+        assertThat(new ColumnType(JDBCType.TIME, true).getJavaType()).isEqualTo(Time.class);
+    }
+
+    @Test
+    void getJavaTypeForTimestampReturnsTimestamp() {
+        assertThat(new ColumnType(JDBCType.TIMESTAMP, true).getJavaType()).isEqualTo(Timestamp.class);
+    }
+
+    @Test
+    void getJavaTypeForTimestampWithTimezoneReturnsTimestamp() {
+        assertThat(new ColumnType(JDBCType.TIMESTAMP_WITH_TIMEZONE, true).getJavaType())
+                .isEqualTo(Timestamp.class);
+    }
+
+    @Test
+    void getJavaTypeForArrayReturnsArray() {
+        ColumnType elementType = new ColumnType(JDBCType.VARCHAR, 255, 0, true);
+        assertThat(new ColumnType(JDBCType.ARRAY, elementType, true).getJavaType())
+                .isEqualTo(Array.class);
+    }
+
+    @Test
+    void getJavaTypeForNullReturnsObject() {
+        assertThat(new ColumnType(JDBCType.NULL, true).getJavaType()).isEqualTo(Object.class);
+    }
+
+    @Test
+    void getJavaTypeForUnsupportedTypeThrows() {
+        assertThatThrownBy(() -> new ColumnType(JDBCType.BLOB, true).getJavaType())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void getPrecisionForIntegerTypes() {
+        assertThat(new ColumnType(JDBCType.TINYINT, true).getPrecisionOrStringLength())
+                .isEqualTo(3);
+        assertThat(new ColumnType(JDBCType.SMALLINT, true).getPrecisionOrStringLength())
+                .isEqualTo(5);
+        assertThat(new ColumnType(JDBCType.INTEGER, true).getPrecisionOrStringLength())
+                .isEqualTo(10);
+        assertThat(new ColumnType(JDBCType.BIGINT, true).getPrecisionOrStringLength())
+                .isEqualTo(19);
+    }
+
+    @Test
+    void getPrecisionForDecimal() {
+        assertThat(new ColumnType(JDBCType.DECIMAL, 18, 4, true).getPrecisionOrStringLength())
+                .isEqualTo(18);
+    }
+
+    @Test
+    void getScaleForDecimal() {
+        assertThat(new ColumnType(JDBCType.DECIMAL, 18, 4, true).getScale()).isEqualTo(4);
+    }
+
+    @Test
+    void getScaleForIntegerTypesIsZero() {
+        assertThat(new ColumnType(JDBCType.INTEGER, true).getScale()).isEqualTo(0);
+        assertThat(new ColumnType(JDBCType.BIGINT, true).getScale()).isEqualTo(0);
+    }
+
+    @Test
+    void isSignedForNumericTypes() {
+        assertThat(new ColumnType(JDBCType.TINYINT, true).isSigned()).isTrue();
+        assertThat(new ColumnType(JDBCType.INTEGER, true).isSigned()).isTrue();
+        assertThat(new ColumnType(JDBCType.DOUBLE, true).isSigned()).isTrue();
+        assertThat(new ColumnType(JDBCType.DECIMAL, 10, 2, true).isSigned()).isTrue();
+    }
+
+    @Test
+    void isSignedForNonNumericTypes() {
+        assertThat(new ColumnType(JDBCType.VARCHAR, 255, 0, true).isSigned()).isFalse();
+        assertThat(new ColumnType(JDBCType.BOOLEAN, true).isSigned()).isFalse();
+        assertThat(new ColumnType(JDBCType.DATE, true).isSigned()).isFalse();
+    }
+
+    @Test
+    void getDisplaySizeForIntegerIncludesSign() {
+        assertThat(new ColumnType(JDBCType.INTEGER, true).getDisplaySize()).isEqualTo(11);
+    }
+
+    @Test
+    void getDisplaySizeForDecimalWithScaleIncludesSignAndDecimalPoint() {
+        assertThat(new ColumnType(JDBCType.DECIMAL, 10, 2, true).getDisplaySize())
+                .isEqualTo(12);
+    }
+
+    @Test
+    void getDisplaySizeForDecimalWithoutScale() {
+        assertThat(new ColumnType(JDBCType.DECIMAL, 10, 0, true).getDisplaySize())
+                .isEqualTo(11);
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/resultset/SimpleResultSetTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/resultset/SimpleResultSetTest.java
@@ -12,12 +12,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.salesforce.datacloud.jdbc.core.DataCloudMetadataResultSet;
 import com.salesforce.datacloud.jdbc.core.MetadataSchemas;
+import com.salesforce.datacloud.jdbc.core.metadata.ColumnMetadata;
+import com.salesforce.datacloud.jdbc.core.metadata.ColumnType;
 import com.salesforce.datacloud.jdbc.core.metadata.DataCloudResultSetMetaData;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.Clob;
+import java.sql.JDBCType;
 import java.sql.NClob;
 import java.sql.Ref;
 import java.sql.ResultSet;
@@ -412,5 +415,49 @@ class SimpleResultSetTest {
         assertThrows(SQLException.class, () -> resultSet.getObject(col));
         assertThrows(SQLException.class, () -> resultSet.getObject(col, String.class));
         assertThrows(SQLException.class, () -> resultSet.getBigDecimal(col));
+    }
+
+    @Test
+    void tinyintColumnSupportsGetLongGetDoubleGetBigDecimal() throws SQLException {
+        List<ColumnMetadata> schema =
+                Collections.singletonList(new ColumnMetadata("val", new ColumnType(JDBCType.TINYINT, true), "TINYINT"));
+        SimpleResultSet<?> rs = DataCloudMetadataResultSet.of(
+                new DataCloudResultSetMetaData(schema), Arrays.asList(Collections.singletonList(42L)));
+
+        assertTrue(rs.next());
+        assertEquals(42L, rs.getLong(1));
+        assertFalse(rs.wasNull());
+    }
+
+    @Test
+    void tinyintColumnSupportsGetDouble() throws SQLException {
+        List<ColumnMetadata> schema =
+                Collections.singletonList(new ColumnMetadata("val", new ColumnType(JDBCType.TINYINT, true), "TINYINT"));
+        SimpleResultSet<?> rs = DataCloudMetadataResultSet.of(
+                new DataCloudResultSetMetaData(schema), Arrays.asList(Collections.singletonList(7L)));
+
+        assertTrue(rs.next());
+        assertEquals(7.0, rs.getDouble(1));
+    }
+
+    @Test
+    void tinyintColumnSupportsGetBigDecimal() throws SQLException {
+        List<ColumnMetadata> schema =
+                Collections.singletonList(new ColumnMetadata("val", new ColumnType(JDBCType.TINYINT, true), "TINYINT"));
+        SimpleResultSet<?> rs = DataCloudMetadataResultSet.of(
+                new DataCloudResultSetMetaData(schema), Arrays.asList(Collections.singletonList(99L)));
+
+        assertTrue(rs.next());
+        assertEquals(new BigDecimal(99), rs.getBigDecimal(1));
+    }
+
+    @Test
+    void getFloatAcceptsNegativeValuesWithinRange() throws SQLException {
+        int col = 5;
+        SimpleResultSet<?> rs = DataCloudMetadataResultSet.of(
+                new DataCloudResultSetMetaData(MetadataSchemas.COLUMNS), Arrays.asList(rowWithLongAt(col, -42L)));
+
+        assertTrue(rs.next());
+        assertEquals(-42.0f, rs.getFloat(col));
     }
 }

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/MetadataCacheInterceptor.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/http/MetadataCacheInterceptor.java
@@ -8,7 +8,6 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -50,24 +49,18 @@ public class MetadataCacheInterceptor implements Interceptor {
             log.trace("Cache miss for metadata response. Getting from server");
             val response = chain.proceed(request);
 
-            if (response.isSuccessful()) {
-                Optional.of(response)
-                        .map(Response::body)
-                        .map(t -> {
-                            try {
-                                return t.string();
-                            } catch (IOException ex) {
-                                log.error("Caught exception when extracting body from response. {}", cacheKey, ex);
-                                return null;
-                            }
-                        })
-                        .ifPresent(responseString -> {
-                            builder.body(ResponseBody.create(responseString, mediaType));
-                            metaDataCache.put(cacheKey, responseString);
-                        });
-            } else {
+            if (!response.isSuccessful()) {
                 return response;
             }
+
+            val body = response.body();
+            if (body == null) {
+                return response;
+            }
+
+            val responseString = body.string();
+            builder.body(ResponseBody.create(responseString, mediaType));
+            metaDataCache.put(cacheKey, responseString);
         }
 
         return builder.build();

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/http/MetadataCacheInterceptorTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/http/MetadataCacheInterceptorTest.java
@@ -4,13 +4,17 @@
  */
 package com.salesforce.datacloud.jdbc.http;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.salesforce.datacloud.jdbc.auth.ResponseEnum;
+import java.io.IOException;
 import lombok.SneakyThrows;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -61,6 +65,44 @@ public class MetadataCacheInterceptorTest {
                 .url(URL)
                 .method(POST, RequestBody.create("{test: test}", MediaType.parse("application/json")))
                 .build();
+    }
+
+    @Test
+    @SneakyThrows
+    public void testMetadataRequestWithBodyReadFailurePropagatesException() {
+        ResponseBody failingBody = mock(ResponseBody.class);
+        when(failingBody.string()).thenThrow(new IOException("network error"));
+
+        Response failingResponse = new Response.Builder()
+                .code(200)
+                .request(buildRequest())
+                .protocol(Protocol.HTTP_1_1)
+                .message("OK")
+                .body(failingBody)
+                .build();
+
+        doReturn(failingResponse).when(chain).proceed(any(Request.class));
+
+        assertThatThrownBy(() -> metadataCacheInterceptor.intercept(chain))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("network error");
+    }
+
+    @Test
+    @SneakyThrows
+    public void testMetadataRequestWithNullBodyReturnsOriginalResponse() {
+        Response nullBodyResponse = new Response.Builder()
+                .code(200)
+                .request(buildRequest())
+                .protocol(Protocol.HTTP_1_1)
+                .message("OK")
+                .body(null)
+                .build();
+
+        doReturn(nullBodyResponse).when(chain).proceed(any(Request.class));
+
+        Response result = metadataCacheInterceptor.intercept(chain);
+        assertThat(result).isSameAs(nullBodyResponse);
     }
 
     private Response buildResponse(int statusCode, ResponseEnum responseEnum) {


### PR DESCRIPTION
A collection of small, independent fixes improving JDBC driver compliance and correctness. Each change is trivial in complexity but addresses real client-visible bugs or spec violations.

## DatabaseMetaData JDBC spec compliance

Methods returned null or wrong values, causing NullPointerException in JDBC clients (e.g. calling .split() / .length() on the result) or outright spec non-conformance:

* getNumericFunctions / getStringFunctions / getSystemFunctions / getTimeDateFunctions / getExtraNameCharacters: null -> "" as these specific function templates are not supported by our driver
* getProcedures / getProcedureColumns / getUDTs / getSuperTypes / getSuperTables / getAttributes / getClientInfoProperties / getFunctions / getFunctionColumns / getPseudoColumns: null -> throw SQLFeatureNotSupportedException as that's better than risking a null pointer exception on the consumer side
* nullPlusNonNullIsNull(): false -> true (SQL standard)
* supportsANSI92IntermediateSQL / supportsANSI92FullSQL: true -> false (Hyper does not expose dynamic SQL, assertions, or domain definitions)
* getDefaultTransactionIsolation(): TRANSACTION_SERIALIZABLE ->
  TRANSACTION_NONE (Hyper does not support transactions)
* getResultSetHoldability(): 0 -> HOLD_CURSORS_OVER_COMMIT
* getJDBCMajorVersion(): 1 -> 4 (we implement JDBC 4.x)
* getSQLStateType(): 0 -> DatabaseMetaData.sqlStateSQL

## getColumns() metadata fixes (QueryMetadataUtil)

* DECIMAL_DIGITS was hardcoded to 2 for every column type -> 2 for NUMERIC/DECIMAL/REAL/DOUBLE, 0 otherwise
* CHAR_OCTET_LENGTH was hardcoded to 2 -> column size for VARCHAR/CHAR, null otherwise
* SQL_DATETIME_SUB was empty string -> null (per spec)

## getSchemas() regex bug

Filter patterns 'tableau*' and 'pg_*' were being interpreted as regex 'zero or more of preceding char' - they matched 'tablea' / 'p' but not 'pg_foo'. Fixed to proper prefix anchors '^tableau' and '^pg_' so system schemas are actually excluded.

## ColumnType: add missing JDBC type mappings

getJavaType() threw IllegalArgumentException for TINYINT, DECIMAL, REAL, VARBINARY, and NULL. Added mappings.

## SimpleResultSet.getFloat negative-range bug

Range check used 'v < Float.MIN_VALUE', but Float.MIN_VALUE is the smallest POSITIVE float (~1.4E-45), not the most negative. Any negative value incorrectly threw "out of range". Fixed to 'v < -Float.MAX_VALUE'. Also added wasNull short-circuit and TINYINT case to getLong / getDouble / getBigDecimal switches.

## MetadataCacheInterceptor: propagate IOException

Body read exceptions were swallowed inside an Optional chain and the response returned with no body, causing callers to silently see an empty response. Now IOException from body.string() propagates. Also simplified the Optional chain to explicit early returns.