### PR TITLE
chore: sync hyper_service.proto and error_details.proto with upstream

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudStatement.java
@@ -93,7 +93,7 @@ public class DataCloudStatement implements Statement, AutoCloseable {
     protected QueryParam.Builder getQueryParamBuilder(
             String sql, QueryTimeout queryTimeout, QueryParam.TransferMode transferMode) throws SQLException {
         val builder = QueryParam.newBuilder()
-                .setQuery(sql)
+                .setSql(sql)
                 .setOutputFormat(QueryResultArrowStream.OUTPUT_FORMAT)
                 .setTransferMode(transferMode);
 

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientRetryTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/HyperGrpcClientRetryTest.java
@@ -102,7 +102,7 @@ public class HyperGrpcClientRetryTest {
     @Test
     public void testExecuteQueryWithRetry() {
         Iterator<ExecuteQueryResponse> queryResultIterator = hyperServiceStub.executeQuery(
-                QueryParam.newBuilder().setQuery(query).build());
+                QueryParam.newBuilder().setSql(query).build());
 
         assertDoesNotThrow(() -> {
             boolean responseReceived = false;

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/InterceptedHyperTestBase.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/InterceptedHyperTestBase.java
@@ -193,11 +193,11 @@ public class InterceptedHyperTestBase {
                 .build();
 
         GrpcMock.stubFor(GrpcMock.serverStreamingMethod(HyperServiceGrpc.getExecuteQueryMethod())
-                .withRequest(req -> req.getQuery().equals(query) && req.getTransferMode() == mode)
+                .withRequest(req -> req.getSql().equals(query) && req.getTransferMode() == mode)
                 .willReturn(
                         Stream.concat(Stream.of(first), Stream.of(responses)).collect(Collectors.toList())));
         return QueryParam.newBuilder()
-                .setQuery(query)
+                .setSql(query)
                 .setTransferMode(mode)
                 .setOutputFormat(OutputFormat.ARROW_IPC)
                 .build();

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamCloseTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/StreamCloseTest.java
@@ -63,7 +63,7 @@ public class StreamCloseTest {
         try {
             val stub = HyperServiceGrpc.newStub(channel);
             val queryParam = QueryParam.newBuilder()
-                    .setQuery("select a from generate_series(1, 10000) as s(a)")
+                    .setSql("select a from generate_series(1, 10000) as s(a)")
                     .setTransferMode(QueryParam.TransferMode.ADAPTIVE)
                     .setOutputFormat(OutputFormat.ARROW_IPC)
                     .build();

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/AsyncQueryResultIteratorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/AsyncQueryResultIteratorTest.java
@@ -41,7 +41,7 @@ public class AsyncQueryResultIteratorTest {
             val stub = stubProvider.getStub();
 
             val queryParam = QueryParam.newBuilder()
-                    .setQuery("SELECT s FROM generate_series(1, 100) s")
+                    .setSql("SELECT s FROM generate_series(1, 100) s")
                     .setOutputFormat(OutputFormat.ARROW_IPC)
                     .setTransferMode(QueryParam.TransferMode.SYNC)
                     .build();
@@ -93,7 +93,7 @@ public class AsyncQueryResultIteratorTest {
 
             // Use an invalid query to trigger an error
             val queryParam = QueryParam.newBuilder()
-                    .setQuery("SELECT * FROM non_existent_table")
+                    .setSql("SELECT * FROM non_existent_table")
                     .setOutputFormat(OutputFormat.ARROW_IPC)
                     .setTransferMode(QueryParam.TransferMode.SYNC)
                     .build();
@@ -104,7 +104,7 @@ public class AsyncQueryResultIteratorTest {
 
                 // Async iteration with error handling
                 CompletionStage<Void> iteration =
-                        consumeAllWithErrorHandling(iterator, queryParam.getQuery(), chunkCount, errorHolder);
+                        consumeAllWithErrorHandling(iterator, queryParam.getSql(), chunkCount, errorHolder);
 
                 // Wait for completion
                 iteration.toCompletableFuture().join();

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/AsyncQueryAccessHandleTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/AsyncQueryAccessHandleTest.java
@@ -25,7 +25,7 @@ public class AsyncQueryAccessHandleTest {
             val stub = stubProvider.getStub();
             val param = QueryParam.newBuilder()
                     // Use a huge sleep to ensure that the test is not blocked by query execution
-                    .setQuery("SELECT pg_sleep(10)")
+                    .setSql("SELECT pg_sleep(10)")
                     .setTransferMode(QueryParam.TransferMode.ASYNC)
                     .setOutputFormat(OutputFormat.ARROW_IPC)
                     .build();
@@ -40,7 +40,7 @@ public class AsyncQueryAccessHandleTest {
         LocalHyperTestBase.assertWithStubProvider(stubProvider -> {
             val stub = stubProvider.getStub();
             val param = QueryParam.newBuilder()
-                    .setQuery("SELECT pg_sleep(10)")
+                    .setSql("SELECT pg_sleep(10)")
                     .setTransferMode(QueryParam.TransferMode.ASYNC)
                     // Also works with JSON as this layer is agnostic of output format
                     .setOutputFormat(OutputFormat.JSON_ARRAY)
@@ -56,7 +56,7 @@ public class AsyncQueryAccessHandleTest {
         LocalHyperTestBase.assertWithStubProvider(stubProvider -> {
             val stub = stubProvider.getStub();
             val param = QueryParam.newBuilder()
-                    .setQuery("SELECT a")
+                    .setSql("SELECT a")
                     .setTransferMode(QueryParam.TransferMode.ASYNC)
                     // Also works with JSON to cover that path
                     .setOutputFormat(OutputFormat.ARROW_IPC)

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/QueryResultIteratorFunctionalTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/QueryResultIteratorFunctionalTest.java
@@ -56,7 +56,7 @@ public class QueryResultIteratorFunctionalTest extends InterceptedHyperTestBase 
         val stub = getInterceptedStub();
 
         val query = QueryParam.newBuilder()
-                .setQuery("SELECT g FROM generate_series(1,5) g")
+                .setSql("SELECT g FROM generate_series(1,5) g")
                 .setTransferMode(QueryParam.TransferMode.ADAPTIVE)
                 .setOutputFormat(OutputFormat.JSON_ARRAY)
                 .build();
@@ -79,7 +79,7 @@ public class QueryResultIteratorFunctionalTest extends InterceptedHyperTestBase 
     void canHandleAsyncMode() {
         val stub = getInterceptedStub();
         val query = QueryParam.newBuilder()
-                .setQuery("SELECT g FROM generate_series(1,5) g")
+                .setSql("SELECT g FROM generate_series(1,5) g")
                 .setTransferMode(QueryParam.TransferMode.ASYNC)
                 .setOutputFormat(OutputFormat.JSON_ARRAY)
                 .build();

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/QueryResultIteratorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/QueryResultIteratorTest.java
@@ -352,7 +352,7 @@ public class QueryResultIteratorTest extends InterceptedHyperTestBase {
         val stub = setupStub();
         GrpcMock.stubFor(GrpcMock.serverStreamingMethod(HyperServiceGrpc.getExecuteQueryMethod())
                 .withRequest(req ->
-                        req.getQuery().equals(TEST_QUERY) && req.getTransferMode() == QueryParam.TransferMode.ADAPTIVE)
+                        req.getSql().equals(TEST_QUERY) && req.getTransferMode() == QueryParam.TransferMode.ADAPTIVE)
                 .willReturn(GrpcMock.stream(GrpcMock.response(queryInfoResponse))
                         .and(GrpcMock.statusException(Status.CANCELLED))));
 
@@ -360,7 +360,7 @@ public class QueryResultIteratorTest extends InterceptedHyperTestBase {
         val iterator = QueryResultIterator.of(
                 stub,
                 QueryParam.newBuilder()
-                        .setQuery(TEST_QUERY)
+                        .setSql(TEST_QUERY)
                         .setTransferMode(QueryParam.TransferMode.ADAPTIVE)
                         .build());
 
@@ -412,12 +412,12 @@ public class QueryResultIteratorTest extends InterceptedHyperTestBase {
         val stub = setupStub();
         GrpcMock.stubFor(GrpcMock.serverStreamingMethod(HyperServiceGrpc.getExecuteQueryMethod())
                 .withRequest(req ->
-                        req.getQuery().equals(TEST_QUERY) && req.getTransferMode() == QueryParam.TransferMode.ADAPTIVE)
+                        req.getSql().equals(TEST_QUERY) && req.getTransferMode() == QueryParam.TransferMode.ADAPTIVE)
                 .willReturn(GrpcMock.statusException(Status.CANCELLED)));
         assertThatThrownBy(() -> QueryResultIterator.of(
                                 stub,
                                 QueryParam.newBuilder()
-                                        .setQuery(TEST_QUERY)
+                                        .setSql(TEST_QUERY)
                                         .setTransferMode(QueryParam.TransferMode.ADAPTIVE)
                                         .build())
                         .hasNext())

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryResultIteratorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryResultIteratorTest.java
@@ -49,7 +49,7 @@ class AsyncQueryResultIteratorTest extends InterceptedHyperTestBase {
 
         // Setup executeQuery to return initial data with RUNNING status
         GrpcMock.stubFor(GrpcMock.serverStreamingMethod(HyperServiceGrpc.getExecuteQueryMethod())
-                .withRequest(req -> req.getQuery().equals(TEST_QUERY))
+                .withRequest(req -> req.getSql().equals(TEST_QUERY))
                 .willProxyTo((request, observer) -> {
                     // First response: query info with running status
                     observer.onNext(ExecuteQueryResponse.newBuilder()
@@ -95,7 +95,7 @@ class AsyncQueryResultIteratorTest extends InterceptedHyperTestBase {
                 }));
 
         val queryParam = QueryParam.newBuilder()
-                .setQuery(TEST_QUERY)
+                .setSql(TEST_QUERY)
                 .setOutputFormat(OutputFormat.ARROW_IPC)
                 .setTransferMode(QueryParam.TransferMode.ADAPTIVE)
                 .build();
@@ -144,7 +144,7 @@ class AsyncQueryResultIteratorTest extends InterceptedHyperTestBase {
 
         // Setup executeQuery to return finished status immediately with inline data
         GrpcMock.stubFor(GrpcMock.serverStreamingMethod(HyperServiceGrpc.getExecuteQueryMethod())
-                .withRequest(req -> req.getQuery().equals(TEST_QUERY))
+                .withRequest(req -> req.getSql().equals(TEST_QUERY))
                 .willProxyTo((request, observer) -> {
                     observer.onNext(ExecuteQueryResponse.newBuilder()
                             .setQueryInfo(QueryInfo.newBuilder()
@@ -164,7 +164,7 @@ class AsyncQueryResultIteratorTest extends InterceptedHyperTestBase {
                 }));
 
         val queryParam = QueryParam.newBuilder()
-                .setQuery(TEST_QUERY)
+                .setSql(TEST_QUERY)
                 .setOutputFormat(OutputFormat.ARROW_IPC)
                 .setTransferMode(QueryParam.TransferMode.ADAPTIVE)
                 .build();

--- a/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperDatabaseSetup.java
+++ b/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperDatabaseSetup.java
@@ -46,7 +46,7 @@ public final class HyperDatabaseSetup {
      */
     public static void executeStatement(HyperServiceGrpc.HyperServiceStub stub, String sql) {
         QueryParam param = QueryParam.newBuilder()
-                .setQuery(sql)
+                .setSql(sql)
                 .setOutputFormat(OutputFormat.ARROW_IPC)
                 .setTransferMode(QueryParam.TransferMode.SYNC)
                 .build();
@@ -126,7 +126,7 @@ public final class HyperDatabaseSetup {
     public static void executeStatementWithDatabase(
             HyperServiceGrpc.HyperServiceStub stub, String databasePath, String databaseAlias, String sql) {
         QueryParam param = QueryParam.newBuilder()
-                .setQuery(sql)
+                .setSql(sql)
                 .setOutputFormat(OutputFormat.ARROW_IPC)
                 .setTransferMode(QueryParam.TransferMode.SYNC)
                 .addDatabases(AttachedDatabase.newBuilder()

--- a/jdbc-proto/src/main/proto/error_details.proto
+++ b/jdbc-proto/src/main/proto/error_details.proto
@@ -60,10 +60,7 @@ message ErrorInfo {
   // MANDATORY FIELD
   string primary_message = 1;
   // The SQL state error code
-  // For upstream services:
-  //  - ALLOWED to be empty
-  //  - if set restrict to Class 28 (Invalid Authorization Specification) or
-  //    Class 42 (Syntax Error or Access Rule Violation)
+  // Treated as InternalError, if empty
   string sqlstate = 2;
   // A suggestion on what what to do about the problem
   // Differs from customer_detail by offering advise rather than hard facts

--- a/jdbc-proto/src/main/proto/hyper_service.proto
+++ b/jdbc-proto/src/main/proto/hyper_service.proto
@@ -39,9 +39,17 @@ service HyperService {
   // By default, this call will only return one update before ending the
   // stream. A client can opt into a streaming mode that will continuously push
   // updates until the query is done or a timeout is reached.
+  // The function fails with status code `INTERNAL`/`FAILED_PRECONDITION` if
+  // the original query encountered a system/user error. Then, the error details
+  // are the same as for the original query.
+  // Other error codes indicate that the `GetQueryInfo` call itself failed.
   rpc GetQueryInfo(QueryInfoParam) returns (stream QueryInfo);
   // Retrieve the results of a previous `ExecuteQuery`. See
   // `QueryParam::TransferMode`
+  // The function fails with status code `FAILED_PRECONDITION` if
+  // the original query encountered a system/user error. Use `GetQueryInfo`
+  // to retrieve details.
+  // Other error codes indicate that the `GetQueryResult` call itself failed.
   rpc GetQueryResult(QueryResultParam) returns (stream QueryResult);
   // Attempts to cancel a query started via `ExecuteQuery`.
   // The call is successful regardless of whether the query was actually
@@ -100,7 +108,7 @@ message QueryParam {
   // See
   // https://developer.salesforce.com/docs/data/data-cloud-query-guide/references/dc-sql-reference/
   // for documentation of Hyper's SQL.
-  string query = 1;
+  string sql = 1;
   // Specify the list of attached databases for this query (optional)
   repeated AttachedDatabase databases = 2;
   // Specify the output format for query result data chunks. ARROW_IPC is
@@ -371,6 +379,26 @@ message QueryStatus {
   google.protobuf.Timestamp expiration_time = 6;
   // The Query execution statistics which contains elapsedTime
   QueryExecutionStatistics execution_stats = 7;
+  // The time at which the original result was computed if the result was served
+  // from the query result cache. Not populated for non-cached results.
+  optional google.protobuf.Timestamp result_computed_at = 8;
+  // Details on the staleness of the result.
+  enum Staleness {
+    // Not used since this enum is only used for response fields.
+    // This value is necessary to satisfy the Salesforce proto guidelines.
+    STALENESS_UNSPECIFIED = 0;
+    // The query contains volatile functions (e.g., `CURRENT_TIMESTAMP`)
+    // which have not been re-evaluated since the result was computed.
+    VOLATILE_FUNCTIONS = 1;
+    // The underlying data has changed since the result was computed.
+    STALE_DATA = 2;
+    // The query accesses remote data (e.g., BYOL Live Tables) for which no
+    // version information is available.
+    REMOTE_DATA = 3;
+  }
+  // See `Staleness`
+  // If empty, the result is fresh (i.e., non-stale).
+  repeated Staleness staleness_reasons = 9;
 }
 
 // The query execution stats present in QueryStatus response


### PR DESCRIPTION
Pull latest protos from source of truth. Notable changes:
- Rename `QueryParam.query` to `QueryParam.sql` (field number 1 unchanged). Update all Java call-sites from `setQuery`/`getQuery` to `setSql`/`getSql` on the `QueryParam` builder and protos.