### PR TITLE
refactor: simplify Step.NeedDispatch propagation; harden dispatch path

### DIFF
--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncChunkRangeIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncChunkRangeIterator.java
@@ -4,8 +4,8 @@
  */
 package com.salesforce.datacloud.jdbc.protocol.async;
 
+import com.salesforce.datacloud.jdbc.protocol.async.core.Step;
 import com.salesforce.datacloud.jdbc.protocol.grpc.QueryAccessGrpcClient;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import lombok.NonNull;
@@ -87,7 +87,7 @@ public class AsyncChunkRangeIterator extends AsyncResultRangeIterator {
     }
 
     @Override
-    protected CompletionStage<Optional<QueryResult>> handleEmptyFirstResult() {
+    protected CompletionStage<Step<QueryResult>> handleEmptyFirstResult() {
         if ((chunkId == 1) && (chunkId < limitChunkId)) {
             // In special cases on adaptive timeout Hyper can produce an empty first chunk
             // We thus retry immediately with next chunk in this case
@@ -99,7 +99,7 @@ public class AsyncChunkRangeIterator extends AsyncResultRangeIterator {
                     client.getQueryId(),
                     chunkId - 1,
                     limitChunkId);
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFuture.completedFuture(Step.<QueryResult>done());
         }
     }
 }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncExecuteQueryIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncExecuteQueryIterator.java
@@ -6,9 +6,9 @@ package com.salesforce.datacloud.jdbc.protocol.async;
 
 import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncIterator;
 import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncStreamObserverIterator;
+import com.salesforce.datacloud.jdbc.protocol.async.core.Step;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -34,6 +34,10 @@ import salesforce.cdp.hyperdb.v1.QueryStatus;
  *
  * <p>CANCELLED errors are treated as normal stream completion, as the V3 protocol
  * uses cancellation to signal expected end-of-stream in case of server side RPC timeout.</p>
+ *
+ * <p>The {@code executeQuery} stub call is started eagerly in {@link #of} on the caller thread,
+ * so this iterator never needs to emit {@link Step.NeedDispatch} during iteration — it only
+ * forwards {@link Step.Value}/{@link Step.Done} from the underlying stream observer.</p>
  */
 @Slf4j
 @AllArgsConstructor
@@ -70,29 +74,31 @@ public class AsyncExecuteQueryIterator implements AsyncIterator<QueryResult> {
     }
 
     @Override
-    public CompletionStage<Optional<QueryResult>> next() {
+    public CompletionStage<Step<QueryResult>> next() {
         return fetchNext();
     }
 
-    private CompletionStage<Optional<QueryResult>> fetchNext() {
+    private CompletionStage<Step<QueryResult>> fetchNext() {
         return streamIterator
                 .next()
-                .thenCompose(opt -> {
-                    if (opt.isPresent()) {
-                        ExecuteQueryResponse response = opt.get();
+                .thenCompose(step -> {
+                    if (step instanceof Step.Value) {
+                        ExecuteQueryResponse response = ((Step.Value<ExecuteQueryResponse>) step).getItem();
                         if (response.hasQueryResult()) {
-                            return CompletableFuture.completedFuture(Optional.of(response.getQueryResult()));
+                            return CompletableFuture.completedFuture(Step.value(response.getQueryResult()));
                         }
-
                         if (response.hasQueryInfo()) {
                             queryInfo = response.getQueryInfo();
                         }
-
                         // Not a result, fetch next message
                         return fetchNext();
+                    } else if (step instanceof Step.NeedDispatch) {
+                        return CompletableFuture.completedFuture(
+                                Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+                    } else if (step instanceof Step.Done) {
+                        return CompletableFuture.completedFuture(Step.<QueryResult>done());
                     }
-                    // Stream ended normally
-                    return CompletableFuture.completedFuture(Optional.empty());
+                    throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
                 })
                 .exceptionally(error -> {
                     // Handle errors - convert CANCELLED to end-of-stream if we have query info
@@ -105,7 +111,7 @@ public class AsyncExecuteQueryIterator implements AsyncIterator<QueryResult> {
                     if (cause instanceof StatusRuntimeException) {
                         StatusRuntimeException ex = (StatusRuntimeException) cause;
                         if (ex.getStatus().getCode() == Status.Code.CANCELLED && (queryInfo != null)) {
-                            return Optional.empty();
+                            return Step.done();
                         }
                     }
                     // Re-throw other errors

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncExecuteQueryIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncExecuteQueryIterator.java
@@ -93,10 +93,9 @@ public class AsyncExecuteQueryIterator implements AsyncIterator<QueryResult> {
                         // Not a result, fetch next message
                         return fetchNext();
                     } else if (step instanceof Step.NeedDispatch) {
-                        return CompletableFuture.completedFuture(
-                                Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+                        return CompletableFuture.completedFuture(Step.retypeNeedDispatch((Step.NeedDispatch<?>) step));
                     } else if (step instanceof Step.Done) {
-                        return CompletableFuture.completedFuture(Step.<QueryResult>done());
+                        return CompletableFuture.completedFuture(Step.done());
                     }
                     throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
                 })

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryInfoIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryInfoIterator.java
@@ -6,10 +6,10 @@ package com.salesforce.datacloud.jdbc.protocol.async;
 
 import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncIterator;
 import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncStreamObserverIterator;
+import com.salesforce.datacloud.jdbc.protocol.async.core.Step;
 import com.salesforce.datacloud.jdbc.protocol.grpc.QueryAccessGrpcClient;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -28,6 +28,13 @@ import salesforce.cdp.hyperdb.v1.QueryStatus;
  *
  * <p>This iterator keeps iterating until the query is finished. For finished queries it'll do
  * at most a single RPC call and return all infos returned from that call.</p>
+ *
+ * <p>When this iterator needs to start a new {@code getQueryInfo} stream, it does NOT call the
+ * gRPC stub from inside the {@link CompletionStage} chain (which would run on a gRPC executor
+ * thread). Instead it emits {@link Step.NeedDispatch}; the synchronous pump runs the stub call
+ * on the caller thread so {@link io.grpc.ClientInterceptor#interceptCall} {@code start} callbacks
+ * observe caller-thread {@link ThreadLocal}s. The retry path on CANCELLED also flows through
+ * this same NeedDispatch mechanism, so retries also dispatch on the caller thread.</p>
  */
 @Slf4j
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -52,19 +59,27 @@ public class AsyncQueryInfoIterator implements AsyncIterator<QueryInfo> {
     private int retryCount;
 
     @Override
-    public CompletionStage<Optional<QueryInfo>> next() {
+    public CompletionStage<Step<QueryInfo>> next() {
         return nextInternal();
     }
 
-    private CompletionStage<Optional<QueryInfo>> nextInternal() {
-        // If we're finished, return empty
+    private CompletionStage<Step<QueryInfo>> nextInternal() {
+        // If we're finished, return done
         if (isQueryFinished) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFuture.completedFuture(Step.<QueryInfo>done());
         }
 
-        // If we don't have an iterator yet, create one
+        // If we don't have an iterator yet, ask the pump to dispatch a new gRPC call on the
+        // caller thread.
         if (iterator == null) {
-            startNewGrpcCall();
+            QueryInfoParam request =
+                    client.getQueryInfoParamBuilder().setStreaming(true).build();
+            String message = String.format("getQueryInfo queryId=%s, streaming=%s", client.getQueryId(), true);
+            final AsyncStreamObserverIterator<QueryInfoParam, QueryInfo> newIter =
+                    new AsyncStreamObserverIterator<>(message, log);
+            iterator = newIter;
+            Runnable dispatch = () -> client.getStub().getQueryInfo(request, newIter.getObserver());
+            return CompletableFuture.completedFuture(Step.<QueryInfo>needDispatch(dispatch));
         }
 
         // Request next from current iterator
@@ -77,7 +92,7 @@ public class AsyncQueryInfoIterator implements AsyncIterator<QueryInfo> {
      * Attempts to retry on CANCELLED errors, up to 2 retries.
      * If no retry is needed or possible, returns the result or error as-is.
      */
-    private CompletionStage<Optional<QueryInfo>> attemptRetry(Optional<QueryInfo> result, Throwable error) {
+    private CompletionStage<Step<QueryInfo>> attemptRetry(Step<QueryInfo> result, Throwable error) {
         // No need to retry
         if (result != null) {
             return CompletableFuture.completedFuture(result);
@@ -97,13 +112,14 @@ public class AsyncQueryInfoIterator implements AsyncIterator<QueryInfo> {
                 ++retryCount;
                 iterator = null;
                 // This will recursively call nextInternal() again but is bounded by the
-                // retry count. If this returns failure the retries are exhausted
+                // retry count. The recursion re-emits a NeedDispatch for the new getQueryInfo
+                // stream so the retry's stub call also runs on the caller thread.
                 return nextInternal();
             }
         }
 
         // No more retry budget, forward the current error
-        CompletableFuture<Optional<QueryInfo>> future = new CompletableFuture<>();
+        CompletableFuture<Step<QueryInfo>> future = new CompletableFuture<>();
         future.completeExceptionally(cause);
         return future;
     }
@@ -112,33 +128,37 @@ public class AsyncQueryInfoIterator implements AsyncIterator<QueryInfo> {
      * Processes a successful result from the stream.
      * Updates the finished flag based on query status and handles stream end by reconnecting if needed.
      */
-    private CompletionStage<Optional<QueryInfo>> processResult(Optional<QueryInfo> value, Throwable error) {
+    private CompletionStage<Step<QueryInfo>> processResult(Step<QueryInfo> step, Throwable error) {
         // If there is an error we forward it
         if (error != null) {
-            CompletableFuture<Optional<QueryInfo>> future = new CompletableFuture<>();
+            CompletableFuture<Step<QueryInfo>> future = new CompletableFuture<>();
             future.completeExceptionally(error);
             return future;
         }
 
-        // Process the value
-        if (value.isPresent()) {
+        if (step instanceof Step.Value) {
             retryCount = 0;
-            QueryInfo info = value.get();
+            QueryInfo info = ((Step.Value<QueryInfo>) step).getItem();
             if (info.hasQueryStatus()) {
                 isQueryFinished =
                         (info.getQueryStatus().getCompletionStatus() == QueryStatus.CompletionStatus.FINISHED);
             }
-            return CompletableFuture.completedFuture(Optional.of(info));
-        } else {
+            return CompletableFuture.completedFuture(Step.<QueryInfo>value(info));
+        } else if (step instanceof Step.NeedDispatch) {
+            // The underlying AsyncStreamObserverIterator never emits NeedDispatch today, but a
+            // safe upcast keeps this code correct if it ever does.
+            return CompletableFuture.completedFuture(Step.<QueryInfo>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+        } else if (step instanceof Step.Done) {
             // Stream ended without value
             if (isQueryFinished) {
-                return CompletableFuture.completedFuture(Optional.empty());
+                return CompletableFuture.completedFuture(Step.<QueryInfo>done());
             }
             // Need to start a new stream
             ++retryCount;
             iterator = null;
             return nextInternal();
         }
+        throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
     }
 
     /**
@@ -153,17 +173,6 @@ public class AsyncQueryInfoIterator implements AsyncIterator<QueryInfo> {
             java.util.function.BiFunction<? super T, Throwable, ? extends CompletionStage<U>> fn) {
 
         return source.handle(fn).thenCompose(Function.identity());
-    }
-
-    /**
-     * Starts a new streaming gRPC call to fetch query info updates.
-     */
-    private void startNewGrpcCall() {
-        QueryInfoParam request =
-                client.getQueryInfoParamBuilder().setStreaming(true).build();
-        String message = String.format("getQueryInfo queryId=%s, streaming=%s", client.getQueryId(), true);
-        iterator = new AsyncStreamObserverIterator<>(message, log);
-        client.getStub().getQueryInfo(request, iterator.getObserver());
     }
 
     @Override

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryInfoIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryInfoIterator.java
@@ -147,11 +147,11 @@ public class AsyncQueryInfoIterator implements AsyncIterator<QueryInfo> {
         } else if (step instanceof Step.NeedDispatch) {
             // The underlying AsyncStreamObserverIterator never emits NeedDispatch today, but a
             // safe upcast keeps this code correct if it ever does.
-            return CompletableFuture.completedFuture(Step.<QueryInfo>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+            return CompletableFuture.completedFuture(Step.retypeNeedDispatch((Step.NeedDispatch<?>) step));
         } else if (step instanceof Step.Done) {
             // Stream ended without value
             if (isQueryFinished) {
-                return CompletableFuture.completedFuture(Step.<QueryInfo>done());
+                return CompletableFuture.completedFuture(Step.done());
             }
             // Need to start a new stream
             ++retryCount;

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryResultIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryResultIterator.java
@@ -6,8 +6,8 @@ package com.salesforce.datacloud.jdbc.protocol.async;
 
 import com.salesforce.datacloud.jdbc.protocol.QueryAccessHandle;
 import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncIterator;
+import com.salesforce.datacloud.jdbc.protocol.async.core.Step;
 import com.salesforce.datacloud.jdbc.protocol.grpc.QueryAccessGrpcClient;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import lombok.AccessLevel;
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import salesforce.cdp.hyperdb.v1.HyperServiceGrpc;
 import salesforce.cdp.hyperdb.v1.OutputFormat;
+import salesforce.cdp.hyperdb.v1.QueryInfo;
 import salesforce.cdp.hyperdb.v1.QueryParam;
 import salesforce.cdp.hyperdb.v1.QueryResult;
 import salesforce.cdp.hyperdb.v1.QueryStatus;
@@ -28,6 +29,10 @@ import salesforce.cdp.hyperdb.v1.QueryStatus;
  *
  * <p>This is the async equivalent of
  * {@link com.salesforce.datacloud.jdbc.protocol.QueryResultIterator}.</p>
+ *
+ * <p>{@link Step.NeedDispatch} produced by sub-iterators ({@code AsyncQueryInfoIterator},
+ * {@code AsyncChunkRangeIterator}) is propagated upward unchanged so the synchronous pump runs
+ * the dispatch thunk on the caller thread.</p>
  */
 @Slf4j
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -81,29 +86,31 @@ public class AsyncQueryResultIterator implements AsyncIterator<QueryResult>, Que
     }
 
     @Override
-    public CompletionStage<Optional<QueryResult>> next() {
+    public CompletionStage<Step<QueryResult>> next() {
         // If execute query stream is not exhausted, try to get next from it
         if (!executeQueryStreamExhausted) {
-            return AsyncQueryInfoIterator.handleCompose(executeQueryIterator.next(), (opt, error) -> {
+            return AsyncQueryInfoIterator.handleCompose(executeQueryIterator.next(), (step, error) -> {
                 // Always try to update queryStatus
                 if (executeQueryIterator.getQueryStatus() != null) {
                     queryStatus = executeQueryIterator.getQueryStatus();
                 }
 
                 if (error != null) {
-                    CompletableFuture<Optional<QueryResult>> future = new CompletableFuture<>();
+                    CompletableFuture<Step<QueryResult>> future = new CompletableFuture<>();
                     future.completeExceptionally(error);
                     return future;
-                } else {
-                    if (opt.isPresent()) {
-
-                        return CompletableFuture.completedFuture(opt);
-                    }
+                } else if (step instanceof Step.Value) {
+                    return CompletableFuture.completedFuture(step);
+                } else if (step instanceof Step.NeedDispatch) {
+                    return CompletableFuture.completedFuture(
+                            Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+                } else if (step instanceof Step.Done) {
                     // Execute query stream ended, continue with chunk fetching
                     executeQueryStreamExhausted = true;
                     initializeQueryClientIfNeeded();
                     return continueWithChunks();
                 }
+                throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
             });
         }
 
@@ -124,18 +131,25 @@ public class AsyncQueryResultIterator implements AsyncIterator<QueryResult>, Que
         }
     }
 
-    private CompletionStage<Optional<QueryResult>> continueWithChunks() {
+    private CompletionStage<Step<QueryResult>> continueWithChunks() {
         // At this point queryClient is guaranteed to be initialized
 
         // If we have an active chunk iterator, try that first
         if (chunkIterator != null) {
-            return chunkIterator.next().thenCompose(opt -> {
-                if (opt.isPresent()) {
-                    return CompletableFuture.completedFuture(opt);
+            return chunkIterator.next().thenCompose(step -> {
+                if (step instanceof Step.Value) {
+                    return CompletableFuture.completedFuture(step);
+                } else if (step instanceof Step.NeedDispatch) {
+                    // Propagate NeedDispatch from the chunk iterator's stub call so the pump runs
+                    // it on the caller thread.
+                    return CompletableFuture.completedFuture(
+                            Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+                } else if (step instanceof Step.Done) {
+                    // Chunk iterator exhausted
+                    chunkIterator = null;
+                    return continueWithChunks();
                 }
-                // Chunk iterator exhausted
-                chunkIterator = null;
-                return continueWithChunks();
+                throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
             });
         }
 
@@ -150,29 +164,35 @@ public class AsyncQueryResultIterator implements AsyncIterator<QueryResult>, Que
         // Check if query is finished
         if (((queryStatus.getCompletionStatus() == QueryStatus.CompletionStatus.FINISHED)
                 || (queryStatus.getCompletionStatus() == QueryStatus.CompletionStatus.RESULTS_PRODUCED))) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFuture.completedFuture(Step.<QueryResult>done());
         }
 
         // Need to poll for more info
         return pollForMoreChunks();
     }
 
-    private CompletionStage<Optional<QueryResult>> pollForMoreChunks() {
-        return infoMessages.next().thenCompose(opt -> {
-            if (opt.isPresent()) {
-                if (opt.get().hasQueryStatus()) {
-                    queryStatus = opt.get().getQueryStatus();
+    private CompletionStage<Step<QueryResult>> pollForMoreChunks() {
+        return infoMessages.next().thenCompose(step -> {
+            if (step instanceof Step.Value) {
+                QueryInfo info = ((Step.Value<QueryInfo>) step).getItem();
+                if (info.hasQueryStatus()) {
+                    queryStatus = info.getQueryStatus();
                     return continueWithChunks();
                 } else {
                     return pollForMoreChunks();
                 }
+            } else if (step instanceof Step.NeedDispatch) {
+                // Forward the info iterator's NeedDispatch upward.
+                return CompletableFuture.completedFuture(
+                        Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+            } else if (step instanceof Step.Done) {
+                // Should never happen — callers of pollForMoreChunks should not call it when
+                // the query is already finished.
+                CompletableFuture<Step<QueryResult>> future = new CompletableFuture<>();
+                future.completeExceptionally(new RuntimeException("Unexpected end in next()"));
+                return future;
             }
-
-            // This should never happen, callers of pollForMoreChunks should not call it when the query is already
-            // finished
-            CompletableFuture<Optional<QueryResult>> future = new CompletableFuture<>();
-            future.completeExceptionally(new RuntimeException("Unexpected end in next()"));
-            return future;
+            throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
         });
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryResultIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryResultIterator.java
@@ -102,8 +102,7 @@ public class AsyncQueryResultIterator implements AsyncIterator<QueryResult>, Que
                 } else if (step instanceof Step.Value) {
                     return CompletableFuture.completedFuture(step);
                 } else if (step instanceof Step.NeedDispatch) {
-                    return CompletableFuture.completedFuture(
-                            Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+                    return CompletableFuture.completedFuture(Step.retypeNeedDispatch((Step.NeedDispatch<?>) step));
                 } else if (step instanceof Step.Done) {
                     // Execute query stream ended, continue with chunk fetching
                     executeQueryStreamExhausted = true;
@@ -142,8 +141,7 @@ public class AsyncQueryResultIterator implements AsyncIterator<QueryResult>, Que
                 } else if (step instanceof Step.NeedDispatch) {
                     // Propagate NeedDispatch from the chunk iterator's stub call so the pump runs
                     // it on the caller thread.
-                    return CompletableFuture.completedFuture(
-                            Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+                    return CompletableFuture.completedFuture(Step.retypeNeedDispatch((Step.NeedDispatch<?>) step));
                 } else if (step instanceof Step.Done) {
                     // Chunk iterator exhausted
                     chunkIterator = null;
@@ -183,8 +181,7 @@ public class AsyncQueryResultIterator implements AsyncIterator<QueryResult>, Que
                 }
             } else if (step instanceof Step.NeedDispatch) {
                 // Forward the info iterator's NeedDispatch upward.
-                return CompletableFuture.completedFuture(
-                        Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+                return CompletableFuture.completedFuture(Step.retypeNeedDispatch((Step.NeedDispatch<?>) step));
             } else if (step instanceof Step.Done) {
                 // Should never happen — callers of pollForMoreChunks should not call it when
                 // the query is already finished.

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncResultRangeIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncResultRangeIterator.java
@@ -6,8 +6,8 @@ package com.salesforce.datacloud.jdbc.protocol.async;
 
 import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncIterator;
 import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncStreamObserverIterator;
+import com.salesforce.datacloud.jdbc.protocol.async.core.Step;
 import com.salesforce.datacloud.jdbc.protocol.grpc.QueryAccessGrpcClient;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +36,18 @@ import salesforce.cdp.hyperdb.v1.QueryResultParam;
  *
  * <p>The returned {@link CompletionStage} from {@link #next()} may complete exceptionally with
  * {@link io.grpc.StatusRuntimeException} if a gRPC error occurs.</p>
+ *
+ * <p>When this iterator needs to start a new {@code getQueryResult} stream, it does NOT call
+ * the gRPC stub from inside the {@link CompletionStage} chain (which would run on a gRPC
+ * executor thread). Instead, it emits {@link Step.NeedDispatch}; the synchronous pump then
+ * runs the stub call on the caller thread so {@link io.grpc.ClientInterceptor#interceptCall}
+ * {@code start} callbacks observe caller-thread {@link ThreadLocal}s.</p>
+ *
+ * <p>This iterator is not safe for concurrent calls to {@link #next()}; callers must wait for
+ * the previous {@link CompletionStage} to complete before calling again, per the
+ * {@link AsyncIterator#next()} contract. The {@code awaitingFirstResponseFromNew} flag and
+ * other instance fields are mutated without synchronization and rely on the happens-before
+ * relationship established by completion of the prior stage.</p>
  */
 @Slf4j
 public abstract class AsyncResultRangeIterator implements AsyncIterator<QueryResult> {
@@ -48,6 +60,13 @@ public abstract class AsyncResultRangeIterator implements AsyncIterator<QueryRes
     protected boolean omitSchema;
     /** The current gRPC stream iterator, null if no active stream. */
     protected AsyncStreamObserverIterator<QueryResultParam, QueryResult> iterator;
+    /**
+     * Marker that the next response observed will be the first from a freshly created iterator.
+     * Set when {@link Step.NeedDispatch} is emitted for a new stream, cleared as soon as the
+     * stream produces a step. Used to drive {@link #handleEmptyFirstResult()} when the new
+     * stream produces no data.
+     */
+    private boolean awaitingFirstResponseFromNew;
 
     protected AsyncResultRangeIterator(QueryAccessGrpcClient client, OutputFormat outputFormat, boolean omitSchema) {
         this.client = client;
@@ -94,55 +113,65 @@ public abstract class AsyncResultRangeIterator implements AsyncIterator<QueryRes
     /**
      * Handles the case when a newly created iterator returns empty on first request.
      *
-     * <p>The default implementation returns empty, signaling end of iteration.
+     * <p>The default implementation returns {@link Step#done()}, signaling end of iteration.
      * Subclasses can override to implement retry logic (e.g., for empty first chunks).</p>
      *
      * @return a CompletionStage with the result to return
      */
-    protected CompletionStage<Optional<QueryResult>> handleEmptyFirstResult() {
-        return CompletableFuture.completedFuture(Optional.empty());
+    protected CompletionStage<Step<QueryResult>> handleEmptyFirstResult() {
+        return CompletableFuture.completedFuture(Step.<QueryResult>done());
     }
 
     @Override
-    public CompletionStage<Optional<QueryResult>> next() {
-        return fetchNext(false);
+    public CompletionStage<Step<QueryResult>> next() {
+        return fetchNext();
     }
 
     /**
-     * Fetches the next result, creating a new gRPC stream if needed.
-     *
-     * @param isFirstFromNewIterator true if this is the first fetch from a newly created iterator
-     * @return a CompletionStage with the next result or empty if iteration is complete
+     * Fetches the next result, emitting {@link Step.NeedDispatch} when a new gRPC stream needs
+     * to be started.
      */
-    private CompletionStage<Optional<QueryResult>> fetchNext(boolean isFirstFromNewIterator) {
-        // If no active iterator, try to create one
+    private CompletionStage<Step<QueryResult>> fetchNext() {
+        // If no active iterator, ask the pump to dispatch a new gRPC call on the caller thread.
         if (iterator == null) {
             if (!hasMoreToFetch()) {
-                return CompletableFuture.completedFuture(Optional.empty());
+                return CompletableFuture.completedFuture(Step.<QueryResult>done());
             }
-            // Build request and create new iterator
-            QueryResultParam param = buildQueryResultParam();
-            iterator = new AsyncStreamObserverIterator<>(buildLogMessage(), log);
-            client.getStub().getQueryResult(param, iterator.getObserver());
-            isFirstFromNewIterator = true;
+            // Build request and create the receiving observer/iterator now (so the observer is
+            // wired before the stub call). The stub call itself happens inside the dispatch
+            // thunk, which the synchronous pump executes on the caller thread.
+            final QueryResultParam param = buildQueryResultParam();
+            final AsyncStreamObserverIterator<QueryResultParam, QueryResult> newIter =
+                    new AsyncStreamObserverIterator<>(buildLogMessage(), log);
+            iterator = newIter;
+            awaitingFirstResponseFromNew = true;
+            Runnable dispatch = () -> client.getStub().getQueryResult(param, newIter.getObserver());
+            return CompletableFuture.completedFuture(Step.<QueryResult>needDispatch(dispatch));
         }
 
-        boolean firstFromNew = isFirstFromNewIterator;
-        return iterator.next().thenCompose(opt -> {
-            if (opt.isPresent()) {
-                onResultReceived(opt.get());
+        boolean firstFromNew = awaitingFirstResponseFromNew;
+        awaitingFirstResponseFromNew = false;
+        return iterator.next().thenCompose(step -> {
+            if (step instanceof Step.Value) {
+                QueryResult result = ((Step.Value<QueryResult>) step).getItem();
+                onResultReceived(result);
                 if (!omitSchema) {
                     omitSchema = true;
                 }
-                return CompletableFuture.completedFuture(opt);
+                return CompletableFuture.completedFuture(Step.<QueryResult>value(result));
+            } else if (step instanceof Step.NeedDispatch) {
+                return CompletableFuture.completedFuture(
+                        Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+            } else if (step instanceof Step.Done) {
+                // Current stream exhausted.
+                iterator = null;
+                if (firstFromNew) {
+                    return handleEmptyFirstResult();
+                }
+                // Try to fetch more from a new iterator (which may emit NeedDispatch).
+                return fetchNext();
             }
-            // Iterator exhausted
-            iterator = null;
-            if (firstFromNew) {
-                return handleEmptyFirstResult();
-            }
-            // Try to fetch more from a new iterator
-            return fetchNext(false);
+            throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
         });
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncResultRangeIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncResultRangeIterator.java
@@ -158,10 +158,9 @@ public abstract class AsyncResultRangeIterator implements AsyncIterator<QueryRes
                 if (!omitSchema) {
                     omitSchema = true;
                 }
-                return CompletableFuture.completedFuture(Step.<QueryResult>value(result));
+                return CompletableFuture.completedFuture(Step.value(result));
             } else if (step instanceof Step.NeedDispatch) {
-                return CompletableFuture.completedFuture(
-                        Step.<QueryResult>retypeNeedDispatch((Step.NeedDispatch<?>) step));
+                return CompletableFuture.completedFuture(Step.retypeNeedDispatch((Step.NeedDispatch<?>) step));
             } else if (step instanceof Step.Done) {
                 // Current stream exhausted.
                 iterator = null;

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/AsyncIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/AsyncIterator.java
@@ -5,7 +5,6 @@
 package com.salesforce.datacloud.jdbc.protocol.async.core;
 
 import java.io.Closeable;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -16,16 +15,25 @@ import java.util.concurrent.CompletionStage;
  * <p>The iteration pattern provides natural backpressure: the consumer controls
  * the pace by deciding when to request the next element.</p>
  *
+ * <p>Each call to {@link #next()} produces a {@link Step}: a value, end-of-stream, or a
+ * {@link Step.NeedDispatch} that asks the synchronous consumer to run a side-effecting thunk on
+ * its own thread before requesting again. {@code NeedDispatch} is how follow-up gRPC calls keep
+ * firing on the caller's thread so {@link io.grpc.ClientInterceptor} {@code start} callbacks see
+ * caller-thread {@link ThreadLocal}s.</p>
+ *
  * <p>Usage pattern:</p>
  * <pre>{@code
  * AsyncIterator<T> iterator = ...;
  * iterator.next()
- *     .thenCompose(opt -> {
- *         if (opt.isPresent()) {
- *             process(opt.get());
+ *     .thenCompose(step -> {
+ *         if (step instanceof Step.Value) {
+ *             process(((Step.Value<T>) step).getItem());
  *             return iterator.next(); // continue iteration
+ *         } else if (step instanceof Step.NeedDispatch) {
+ *             ((Step.NeedDispatch<T>) step).getDispatch().run();
+ *             return iterator.next();
  *         } else {
- *             return CompletableFuture.completedFuture(Optional.empty()); // done
+ *             return CompletableFuture.completedFuture(step); // Done
  *         }
  *     });
  * }</pre>
@@ -35,8 +43,7 @@ import java.util.concurrent.CompletionStage;
 public interface AsyncIterator<T> extends Closeable {
 
     /**
-     * Returns a stage that completes with the next item,
-     * or an empty Optional if the iteration is finished.
+     * Returns a stage that completes with the next {@link Step}.
      *
      * <p>The returned stage may complete exceptionally if an error occurs
      * during iteration (e.g., network errors, protocol errors).</p>
@@ -44,17 +51,16 @@ public interface AsyncIterator<T> extends Closeable {
      * <p>Calling {@code next()} again before the previous stage completes
      * results in undefined behavior.</p>
      *
-     * @return a CompletionStage that completes with the next element wrapped in Optional,
-     *         or an empty Optional if no more elements are available
+     * @return a CompletionStage that completes with the next {@link Step}
      */
-    CompletionStage<Optional<T>> next();
+    CompletionStage<Step<T>> next();
 
     /**
      * Closes this iterator and releases any underlying resources.
      * This may cancel ongoing operations.
      *
      * <p>After closing, subsequent calls to {@link #next()} may return
-     * completed stages with empty Optional or fail.</p>
+     * completed stages with {@link Step#done()} or fail.</p>
      */
     @Override
     void close();

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/AsyncStreamObserverIterator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/AsyncStreamObserverIterator.java
@@ -6,12 +6,16 @@ package com.salesforce.datacloud.jdbc.protocol.async.core;
 
 import com.google.protobuf.AbstractMessage;
 import io.grpc.stub.ClientResponseObserver;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import org.slf4j.Logger;
 
 /**
  * Asynchronous iterator over a gRPC response.
+ *
+ * <p>This iterator only consumes an already-running gRPC stream — it never initiates an RPC
+ * itself, so it never emits {@link Step.NeedDispatch}. Each call to {@link #next()} produces
+ * either {@link Step.Value} (next message), {@link Step.Done} (stream completed), or completes
+ * the stage exceptionally on stream error.</p>
  *
  * @param <ReqT>  the request message type
  * @param <RespT> the response message type
@@ -44,11 +48,12 @@ public class AsyncStreamObserverIterator<ReqT, RespT extends AbstractMessage> im
      * {@inheritDoc}
      *
      * <p>Requests the next message from the gRPC stream. The returned stage completes
-     * when a message is received, the stream ends, or an error occurs.</p>
+     * with {@link Step.Value} when a message is received, {@link Step.Done} when the stream ends,
+     * or exceptionally on stream error.</p>
      */
     @Override
-    public CompletionStage<Optional<RespT>> next() {
-        return observer.requestNext();
+    public CompletionStage<Step<RespT>> next() {
+        return observer.requestNext().thenApply(opt -> opt.isPresent() ? Step.value(opt.get()) : Step.<RespT>done());
     }
 
     /**

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/Step.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/Step.java
@@ -1,0 +1,92 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.protocol.async.core;
+
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+/**
+ * Sum-type result of one step of {@link AsyncIterator#next()}.
+ *
+ * <p>The async pump may need to ask its caller for cooperation before producing a value.
+ * Concretely, follow-up gRPC calls (e.g. {@code getQueryInfo}, {@code getQueryResult}) must be
+ * dispatched on the caller's thread so that gRPC {@link io.grpc.ClientInterceptor} {@code start}
+ * callbacks observe the caller's {@link ThreadLocal} state. To make this possible without
+ * threading an executor through the iterator chain, an iterator can return
+ * {@link NeedDispatch}; the synchronous pump then runs the supplied thunk on the caller thread
+ * and re-invokes {@code next()}.</p>
+ *
+ * <p>{@link Value} carries the next produced item. {@link Done} signals end-of-iteration.</p>
+ *
+ * <p>Construction is restricted to the static factories below — the nested subclasses' constructors
+ * are private and {@link Step} itself has a private constructor, so {@code Value / Done / NeedDispatch}
+ * is the closed set of cases consumers must handle. A consumer's {@code instanceof} chain should
+ * cover all three and throw on anything else, so adding a fourth case (a deliberate change inside
+ * this file) trips a runtime failure rather than silently being treated as end-of-iteration.</p>
+ *
+ * @param <T> element type produced by the iterator
+ */
+public abstract class Step<T> {
+
+    private Step() {}
+
+    /**
+     * @return a step carrying the next produced item; {@code item} must be non-null
+     */
+    public static <T> Step<T> value(T item) {
+        return new Value<>(Objects.requireNonNull(item, "Step.value item must be non-null"));
+    }
+
+    /**
+     * @return a step signaling that iteration is complete
+     */
+    public static <T> Step<T> done() {
+        return new Done<>();
+    }
+
+    /**
+     * @return a step asking the synchronous pump to run {@code dispatch} on the caller thread,
+     *         then re-invoke {@code next()}
+     */
+    public static <T> Step<T> needDispatch(Runnable dispatch) {
+        return new NeedDispatch<>(Objects.requireNonNull(dispatch, "Step.needDispatch dispatch must be non-null"));
+    }
+
+    /**
+     * Re-types a {@link NeedDispatch} from one element type to another. The wrapped
+     * {@link Runnable} does not depend on the element type, so this is a safe upcast that
+     * avoids reallocating a new {@code NeedDispatch} at every iterator boundary.
+     */
+    @SuppressWarnings("unchecked")
+    public static <U> Step<U> retypeNeedDispatch(NeedDispatch<?> step) {
+        return (Step<U>) step;
+    }
+
+    /** A produced item. */
+    @lombok.Value
+    @lombok.EqualsAndHashCode(callSuper = false)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static final class Value<T> extends Step<T> {
+        T item;
+    }
+
+    /** End-of-iteration sentinel. */
+    @lombok.EqualsAndHashCode(callSuper = false)
+    public static final class Done<T> extends Step<T> {
+        private Done() {}
+    }
+
+    /**
+     * Sentinel asking the synchronous pump to execute {@code dispatch} on the caller thread,
+     * then re-invoke {@code next()} to continue iteration.
+     */
+    @lombok.Value
+    @lombok.EqualsAndHashCode(callSuper = false)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static final class NeedDispatch<T> extends Step<T> {
+        Runnable dispatch;
+    }
+}

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
@@ -19,6 +19,11 @@ import java.util.concurrent.ExecutionException;
  * It is intended as a compatibility layer for existing synchronous code that cannot be
  * easily migrated to async patterns.</p>
  *
+ * <p>When the underlying async iterator returns a {@link Step.NeedDispatch}, the dispatch thunk
+ * is run on the caller thread (the one currently blocked inside {@link #hasNext()}). This is how
+ * follow-up gRPC calls are kept on the caller's thread so {@link io.grpc.ClientInterceptor}
+ * {@code start} callbacks observe caller-thread {@link ThreadLocal}s.</p>
+ *
  * <p>Thread interruptions during blocking operations will close the underlying async iterator
  * and re-set the thread's interrupt flag.</p>
  *
@@ -53,6 +58,9 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
      * If the thread is interrupted while waiting, the underlying async iterator is closed
      * and the thread's interrupt flag is restored.</p>
      *
+     * <p>If the async iterator returns a {@link Step.NeedDispatch}, its dispatch thunk runs on
+     * this (caller) thread and iteration continues until a value or end-of-stream is observed.</p>
+     *
      * @throws RuntimeException if the underlying async operation fails
      */
     @Override
@@ -67,40 +75,57 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
             return nextValue.isPresent();
         }
 
-        // Block waiting for next value. The future is hoisted out of the loop so that on interrupt
-        // we close the iterator (triggering gRPC cancellation) and then re-wait on the *same* future
-        // rather than requesting a new one (which would hit "Unfulfilled previous future").
-        boolean interrupted = false;
-        CompletableFuture<Optional<T>> future = asyncIterator.next().toCompletableFuture();
-        try {
-            while (true) {
-                try {
-                    nextValue = future.get();
-                    if (!nextValue.isPresent()) {
-                        done = true;
-                    }
-                    return nextValue.isPresent();
-                } catch (InterruptedException ie) {
-                    interrupted = true;
+        // Outer pump: each iteration either gets a value/done, or runs a dispatch thunk and tries again.
+        while (true) {
+            // Block waiting for the next step. The future is hoisted out of the inner loop so that on
+            // interrupt we close the iterator (triggering gRPC cancellation) and then re-wait on the
+            // *same* future rather than requesting a new one (which would hit "Unfulfilled previous future").
+            boolean interrupted = false;
+            CompletableFuture<Step<T>> future = asyncIterator.next().toCompletableFuture();
+            Step<T> step;
+            try {
+                while (true) {
                     try {
-                        asyncIterator.close();
-                    } catch (Exception ignore) {
+                        step = future.get();
+                        break;
+                    } catch (InterruptedException ie) {
+                        interrupted = true;
+                        try {
+                            asyncIterator.close();
+                        } catch (Exception ignore) {
+                        }
+                    } catch (ExecutionException | CompletionException ee) {
+                        // The async stream is permanently dead after an error. Cache the exception so a
+                        // retried hasNext() re-surfaces it instead of requesting a new future (which
+                        // would hit "Unfulfilled previous future" or mask the original error).
+                        Throwable cause = ee.getCause();
+                        terminalError = (cause instanceof RuntimeException)
+                                ? (RuntimeException) cause
+                                : new RuntimeException(cause);
+                        throw terminalError;
                     }
-                } catch (ExecutionException | CompletionException ee) {
-                    // The async stream is permanently dead after an error. Cache the exception so a
-                    // retried hasNext() re-surfaces it instead of requesting a new future (which
-                    // would hit "Unfulfilled previous future" or mask the original error).
-                    Throwable cause = ee.getCause();
-                    terminalError = (cause instanceof RuntimeException)
-                            ? (RuntimeException) cause
-                            : new RuntimeException(cause);
-                    throw terminalError;
+                }
+            } finally {
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
                 }
             }
-        } finally {
-            if (interrupted) {
-                Thread.currentThread().interrupt();
+
+            if (step instanceof Step.NeedDispatch) {
+                // Run the dispatch thunk on this (caller) thread so any gRPC ClientInterceptor.start
+                // callbacks fire here and observe caller-thread ThreadLocals. Then re-pump.
+                ((Step.NeedDispatch<T>) step).getDispatch().run();
+                continue;
+            } else if (step instanceof Step.Value) {
+                T item = ((Step.Value<T>) step).getItem();
+                nextValue = Optional.of(item);
+                return true;
+            } else if (step instanceof Step.Done) {
+                nextValue = Optional.empty();
+                done = true;
+                return false;
             }
+            throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
         }
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapter.java
@@ -114,7 +114,16 @@ public class SyncIteratorAdapter<T> implements CloseableIterator<T> {
             if (step instanceof Step.NeedDispatch) {
                 // Run the dispatch thunk on this (caller) thread so any gRPC ClientInterceptor.start
                 // callbacks fire here and observe caller-thread ThreadLocals. Then re-pump.
-                ((Step.NeedDispatch<T>) step).getDispatch().run();
+                //
+                // If the dispatch thunk throws (e.g. a host interceptor's start() rejects the call),
+                // cache the exception so subsequent hasNext() calls re-surface it rather than
+                // re-driving the iterator into an unspecified state.
+                try {
+                    ((Step.NeedDispatch<T>) step).getDispatch().run();
+                } catch (RuntimeException re) {
+                    terminalError = re;
+                    throw terminalError;
+                }
                 continue;
             } else if (step instanceof Step.Value) {
                 T item = ((Step.Value<T>) step).getItem();

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/AsyncQueryResultIteratorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/examples/AsyncQueryResultIteratorTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.salesforce.datacloud.jdbc.exception.QueryExceptionHandler;
 import com.salesforce.datacloud.jdbc.hyper.LocalHyperTestBase;
 import com.salesforce.datacloud.jdbc.protocol.async.AsyncQueryResultIterator;
+import com.salesforce.datacloud.jdbc.protocol.async.core.Step;
 import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -67,18 +68,19 @@ public class AsyncQueryResultIteratorTest {
      * chains to the next iteration.
      */
     private CompletionStage<Void> consumeAllAsync(AsyncQueryResultIterator iterator, AtomicInteger chunkCount) {
-        return iterator.next().thenCompose(opt -> {
-            if (!opt.isPresent()) {
-                // End of results - return completed future
+        return iterator.next().thenCompose(step -> {
+            if (step instanceof Step.NeedDispatch) {
+                // Drive the dispatch thunk so the gRPC stub call fires; then continue iteration.
+                ((Step.NeedDispatch<?>) step).getDispatch().run();
+                return consumeAllAsync(iterator, chunkCount);
+            } else if (step instanceof Step.Value) {
+                val count = chunkCount.incrementAndGet();
+                log.info("Async: Received chunk {}", count);
+                return consumeAllAsync(iterator, chunkCount);
+            } else if (step instanceof Step.Done) {
                 return CompletableFuture.completedFuture(null);
             }
-
-            // Process this chunk
-            val count = chunkCount.incrementAndGet();
-            log.info("Async: Received chunk {}", count);
-
-            // Chain to next iteration (recursive async call)
-            return consumeAllAsync(iterator, chunkCount);
+            throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
         });
     }
 
@@ -131,12 +133,17 @@ public class AsyncQueryResultIteratorTest {
             AtomicReference<SQLException> errorHolder) {
 
         return iterator.next()
-                .thenCompose(opt -> {
-                    if (!opt.isPresent()) {
-                        return CompletableFuture.completedFuture(null);
+                .thenCompose(step -> {
+                    if (step instanceof Step.NeedDispatch) {
+                        ((Step.NeedDispatch<?>) step).getDispatch().run();
+                        return consumeAllWithErrorHandling(iterator, query, chunkCount, errorHolder);
+                    } else if (step instanceof Step.Value) {
+                        chunkCount.incrementAndGet();
+                        return consumeAllWithErrorHandling(iterator, query, chunkCount, errorHolder);
+                    } else if (step instanceof Step.Done) {
+                        return CompletableFuture.completedFuture((Void) null);
                     }
-                    chunkCount.incrementAndGet();
-                    return consumeAllWithErrorHandling(iterator, query, chunkCount, errorHolder);
+                    throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
                 })
                 .exceptionally(throwable -> {
                     // Unwrap CompletionException if needed

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/SyncIteratorThreadLocalPropagationTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/SyncIteratorThreadLocalPropagationTest.java
@@ -1,0 +1,254 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.salesforce.datacloud.jdbc.core.InterceptedHyperTestBase;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.Value;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import salesforce.cdp.hyperdb.v1.QueryParam;
+import salesforce.cdp.hyperdb.v1.QueryStatus;
+
+/**
+ * Investigates whether a {@link ThreadLocal} set on the caller thread is visible to a gRPC
+ * {@link ClientInterceptor} on every RPC the {@code SyncIteratorAdapter} fires, including the
+ * follow-on {@code getQueryInfo} and {@code getQueryResult} calls that happen lazily as the
+ * caller drains the result.
+ *
+ * <p>The scenario: caller has a {@link ThreadLocal} value (e.g. an audit token, request id, or
+ * routing hint) and an interceptor that reads it. The caller does not want the value moved
+ * into the interceptor's constructor — it must reflect what is set on the calling thread at
+ * the moment of each RPC.</p>
+ *
+ * <p>Each test asserts on which thread the interceptor's {@code start(...)} actually fired
+ * AND what value the {@code ThreadLocal} held at that moment, for every RPC the iterator drove.
+ * This pins down whether the protocol layer's async machinery preserves the caller's
+ * {@code ThreadLocal} through all transitive gRPC calls.</p>
+ */
+public class SyncIteratorThreadLocalPropagationTest extends InterceptedHyperTestBase {
+
+    private static final String QUERY = "SELECT 1 thread_local_test";
+    private static final String QUERY_ID = "tl-test-query-1";
+
+    private static final ThreadLocal<String> CALLER_TL = new ThreadLocal<>();
+
+    /**
+     * Interceptor that — at the moment {@code start} fires — snapshots the current thread name
+     * and the value of the caller's {@link ThreadLocal}. This is the realistic shape of an
+     * interceptor that "depends on the value of the thread local" (e.g. injecting an
+     * audit/request header derived from caller state).
+     */
+    @Value
+    static class Observation {
+        String method;
+        String threadName;
+        String threadLocalValue;
+    }
+
+    static final class RecordingInterceptor implements ClientInterceptor {
+        final List<Observation> observations = new CopyOnWriteArrayList<>();
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                MethodDescriptor<ReqT, RespT> method, CallOptions options, Channel next) {
+            return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, options)) {
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                    observations.add(new Observation(
+                            method.getFullMethodName(), Thread.currentThread().getName(), CALLER_TL.get()));
+                    super.start(responseListener, headers);
+                }
+            };
+        }
+    }
+
+    @Test
+    public void singleRpcOnly_executeQueryInlineFinished_threadLocalIsSeen() {
+        // Scenario: query finishes inline on the executeQuery stream, no follow-up RPCs.
+        // executeQuery is started synchronously from QueryResultIterator.of(...) on the
+        // caller thread, so the ThreadLocal must be visible to the interceptor.
+        val recorder = new RecordingInterceptor();
+        val stub = getInterceptedStub().withInterceptors(recorder);
+        val params = setupExecuteQuery(
+                QUERY_ID,
+                QUERY,
+                QueryParam.TransferMode.ADAPTIVE,
+                executeQueryResponse(QUERY_ID, QueryStatus.CompletionStatus.FINISHED, 1));
+
+        val callerThread = Thread.currentThread().getName();
+        CALLER_TL.set("token-A");
+        try {
+            val iterator = QueryResultIterator.of(stub, params);
+            // Drain the iterator end-to-end on the caller thread.
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+        } finally {
+            CALLER_TL.remove();
+        }
+
+        assertThat(recorder.observations).hasSize(1);
+        val executeObs = recorder.observations.get(0);
+        assertThat(executeObs.getMethod()).endsWith("/ExecuteQuery");
+        assertThat(executeObs.getThreadName()).isEqualTo(callerThread);
+        assertThat(executeObs.getThreadLocalValue()).isEqualTo("token-A");
+    }
+
+    @Test
+    public void multiRpc_executeQuery_thenGetQueryInfo_thenGetQueryResult_threadLocalIsSeenOnEveryCall() {
+        // Scenario: the iterator must do all three RPCs in sequence:
+        //   1. executeQuery returns RUNNING — no inline data
+        //   2. getQueryInfo polls and returns FINISHED with a chunk count of 2
+        //   3. getQueryResult fetches chunk 1
+        // Calls 2 and 3 are kicked off from inside thenCompose() callbacks on the gRPC executor
+        // thread, NOT from the caller thread. If the protocol layer doesn't preserve the
+        // caller's ThreadLocal, those calls will see a null/wrong value.
+        val recorder = new RecordingInterceptor();
+        val stub = getInterceptedStub().withInterceptors(recorder);
+        val params = setupExecuteQuery(
+                QUERY_ID,
+                QUERY,
+                QueryParam.TransferMode.ADAPTIVE,
+                executeQueryResponse(QUERY_ID, QueryStatus.CompletionStatus.RUNNING_OR_UNSPECIFIED, 1));
+        setupGetQueryInfo(QUERY_ID, QueryStatus.CompletionStatus.FINISHED, 2);
+        setupGetQueryResult(QUERY_ID, 1, 1, Collections.emptyList());
+
+        val callerThread = Thread.currentThread().getName();
+        CALLER_TL.set("token-B");
+        try {
+            val iterator = QueryResultIterator.of(stub, params);
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+        } finally {
+            CALLER_TL.remove();
+        }
+
+        // Sanity: we drove all three call types.
+        assertThat(recorder.observations)
+                .extracting(Observation::getMethod)
+                .anyMatch(m -> m.endsWith("/ExecuteQuery"))
+                .anyMatch(m -> m.endsWith("/GetQueryInfo"))
+                .anyMatch(m -> m.endsWith("/GetQueryResult"));
+
+        // The first RPC (ExecuteQuery) is started synchronously from QueryResultIterator.of()
+        // and therefore runs on the caller thread.
+        val executeObs = recorder.observations.stream()
+                .filter(o -> o.getMethod().endsWith("/ExecuteQuery"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("ExecuteQuery RPC was not observed"));
+        assertThat(executeObs.getThreadName())
+                .as("ExecuteQuery is started synchronously from of(), so it runs on the caller thread")
+                .isEqualTo(callerThread);
+        assertThat(executeObs.getThreadLocalValue())
+                .as("ExecuteQuery interceptor should observe the caller's thread-local")
+                .isEqualTo("token-B");
+
+        // The follow-up RPCs are dispatched from inside thenCompose() callbacks. The protocol
+        // layer's contract is that the dispatch thunk runs on the caller thread, so the
+        // interceptor's start(...) must fire on that same thread AND see the caller's
+        // ThreadLocal. Asserting both pins the contract end-to-end — a future implementation
+        // that snapshots the value but dispatches on a worker thread would still satisfy the
+        // value check but break the thread-identity invariant.
+        for (Observation obs : recorder.observations) {
+            if (obs.getMethod().endsWith("/ExecuteQuery")) {
+                continue;
+            }
+            assertThat(obs.getThreadName())
+                    .as("Follow-up RPC %s should fire on the caller thread, not a gRPC executor", obs.getMethod())
+                    .isEqualTo(callerThread);
+            assertThat(obs.getThreadLocalValue())
+                    .as(
+                            "Interceptor observation for %s on thread '%s' — caller thread was '%s'."
+                                    + " A null here means the caller's ThreadLocal did NOT propagate"
+                                    + " into the gRPC executor thread that fired this RPC.",
+                            obs.getMethod(), obs.getThreadName(), callerThread)
+                    .isEqualTo("token-B");
+        }
+    }
+
+    @Test
+    public void multiRpc_threadLocalChangedBetweenHasNextCalls_isReflectedOnNextRpc() {
+        // Scenario: caller mutates the ThreadLocal between drains. The protocol layer should
+        // reflect the *current* caller-thread value on RPCs that are dispatched while the
+        // caller is sitting in hasNext()/next() — not a snapshotted value.
+        //
+        // Concretely: drain the inline ExecuteQuery first under "token-pre", then mutate the
+        // ThreadLocal to "token-post" before triggering the GetQueryInfo + GetQueryResult RPCs.
+        // The first inline result is delivered from executeQuery, which is started on the caller
+        // thread under "token-pre". After draining that, the iterator must do GetQueryInfo +
+        // GetQueryResult to get the next chunk. We probe whether those see "token-post" or not.
+        val recorder = new RecordingInterceptor();
+        val stub = getInterceptedStub().withInterceptors(recorder);
+        val params = setupExecuteQuery(
+                QUERY_ID,
+                QUERY,
+                QueryParam.TransferMode.ADAPTIVE,
+                executeQueryResponse(QUERY_ID, QueryStatus.CompletionStatus.RUNNING_OR_UNSPECIFIED, 1));
+        setupGetQueryInfo(QUERY_ID, QueryStatus.CompletionStatus.FINISHED, 2);
+        setupGetQueryResult(QUERY_ID, 1, 1, Collections.emptyList());
+
+        val callerThread = Thread.currentThread().getName();
+        CALLER_TL.set("token-pre");
+        QueryResultIterator iterator;
+        try {
+            iterator = QueryResultIterator.of(stub, params);
+            // Force ExecuteQuery to be observed under token-pre. hasNext() will block until
+            // the executeQuery stream is drained and chunk fetching begins.
+        } finally {
+            // Simulate the caller swapping the value before the next blocking probe.
+        }
+
+        // ExecuteQuery should already have been recorded under token-pre.
+        val executeObs = recorder.observations.stream()
+                .filter(o -> o.getMethod().endsWith("/ExecuteQuery"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("ExecuteQuery RPC was not observed"));
+        assertThat(executeObs.getThreadLocalValue()).isEqualTo("token-pre");
+
+        // Now flip the ThreadLocal and drive the next round — this drives GetQueryInfo and
+        // GetQueryResult, both started from inside thenCompose callbacks.
+        CALLER_TL.set("token-post");
+        try {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+        } finally {
+            CALLER_TL.remove();
+        }
+
+        // For each follow-on RPC, assert what the interceptor saw. If propagation is broken,
+        // the observed value will be null (interceptor ran on a gRPC executor thread which
+        // never had the caller's ThreadLocal set) or "token-pre" (snapshotted somewhere upstream).
+        // The contract we want is: the value at the moment the RPC was dispatched, which from
+        // the caller's perspective is "token-post".
+        for (Observation obs : recorder.observations) {
+            if (obs.getMethod().endsWith("/ExecuteQuery")) {
+                continue;
+            }
+            assertThat(obs.getThreadName())
+                    .as("Follow-up RPC %s should fire on the caller thread, not a gRPC executor", obs.getMethod())
+                    .isEqualTo(callerThread);
+            assertThat(obs.getThreadLocalValue())
+                    .as(
+                            "Follow-up RPC %s on thread '%s' should observe the caller's"
+                                    + " *current* ThreadLocal value at dispatch time.",
+                            obs.getMethod(), obs.getThreadName())
+                    .isEqualTo("token-post");
+        }
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryResultIteratorTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/AsyncQueryResultIteratorTest.java
@@ -7,6 +7,7 @@ package com.salesforce.datacloud.jdbc.protocol.async;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.salesforce.datacloud.jdbc.core.InterceptedHyperTestBase;
+import com.salesforce.datacloud.jdbc.protocol.async.core.Step;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -30,6 +31,25 @@ class AsyncQueryResultIteratorTest extends InterceptedHyperTestBase {
 
     private HyperServiceGrpc.HyperServiceStub setupStub() {
         return getInterceptedStub().withDeadlineAfter(30000, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Drives the async iterator like the synchronous pump: runs any {@link Step.NeedDispatch}
+     * thunk and re-invokes {@code next()} until a {@link Step.Value} or {@link Step.Done} arrives.
+     */
+    private static <T> CompletableFuture<Optional<T>> drainStep(
+            com.salesforce.datacloud.jdbc.protocol.async.core.AsyncIterator<T> iterator) {
+        return iterator.next().toCompletableFuture().thenCompose(step -> {
+            if (step instanceof Step.NeedDispatch) {
+                ((Step.NeedDispatch<T>) step).getDispatch().run();
+                return drainStep(iterator);
+            } else if (step instanceof Step.Value) {
+                return CompletableFuture.completedFuture(Optional.of(((Step.Value<T>) step).getItem()));
+            } else if (step instanceof Step.Done) {
+                return CompletableFuture.completedFuture(Optional.<T>empty());
+            }
+            throw new IllegalStateException("Unknown Step subtype: " + step.getClass());
+        });
     }
 
     /**
@@ -104,8 +124,7 @@ class AsyncQueryResultIteratorTest extends InterceptedHyperTestBase {
             val resultCount = new AtomicInteger(0);
 
             // First call should return quickly with the inline result
-            CompletableFuture<Optional<QueryResult>> firstFuture =
-                    iterator.next().toCompletableFuture();
+            CompletableFuture<Optional<QueryResult>> firstFuture = drainStep(iterator);
 
             // Should complete quickly since data is available
             Optional<QueryResult> firstResult = firstFuture.get(5, TimeUnit.SECONDS);
@@ -116,8 +135,7 @@ class AsyncQueryResultIteratorTest extends InterceptedHyperTestBase {
             iteratorReceivedFirstResult.countDown();
 
             // Second call will need to poll for query info - this will hang initially
-            CompletableFuture<Optional<QueryResult>> secondFuture =
-                    iterator.next().toCompletableFuture();
+            CompletableFuture<Optional<QueryResult>> secondFuture = drainStep(iterator);
 
             // Verify the future is not completed yet (query info is delayed)
             assertThat(secondFuture.isDone()).isFalse();
@@ -171,11 +189,11 @@ class AsyncQueryResultIteratorTest extends InterceptedHyperTestBase {
 
         try (val iterator = AsyncQueryResultIterator.of(stub, queryParam)) {
             // First result should be available
-            Optional<QueryResult> first = iterator.next().toCompletableFuture().get(5, TimeUnit.SECONDS);
+            Optional<QueryResult> first = drainStep(iterator).get(5, TimeUnit.SECONDS);
             assertThat(first).isPresent();
 
             // Second call should return empty (finished)
-            Optional<QueryResult> second = iterator.next().toCompletableFuture().get(5, TimeUnit.SECONDS);
+            Optional<QueryResult> second = drainStep(iterator).get(5, TimeUnit.SECONDS);
             assertThat(second).isEmpty();
 
             assertThat(iterator.getQueryStatus().getCompletionStatus())

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/async/core/SyncIteratorAdapterTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
@@ -22,14 +21,14 @@ class SyncIteratorAdapterTest {
 
     @Test
     void testInterruptHandlingRestoresInterruptFlag() throws Exception {
-        val blockingFuture = new CompletableFuture<Optional<String>>();
+        val blockingFuture = new CompletableFuture<Step<String>>();
         val closeCalled = new AtomicBoolean(false);
         val iteratorStartedBlocking = new CountDownLatch(1);
 
         // Create an async iterator that blocks indefinitely until closed
         AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
             @Override
-            public CompletionStage<Optional<String>> next() {
+            public CompletionStage<Step<String>> next() {
                 iteratorStartedBlocking.countDown();
                 return blockingFuture;
             }
@@ -77,7 +76,7 @@ class SyncIteratorAdapterTest {
 
     @Test
     void testInterruptWithAsyncCloseSurfacesGrpcError() throws Exception {
-        val blockingFuture = new CompletableFuture<Optional<String>>();
+        val blockingFuture = new CompletableFuture<Step<String>>();
         val closeCalled = new AtomicBoolean(false);
         val iteratorStartedBlocking = new CountDownLatch(1);
 
@@ -85,7 +84,7 @@ class SyncIteratorAdapterTest {
         // The onError callback fires asynchronously after cancellation propagates through gRPC.
         AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
             @Override
-            public CompletionStage<Optional<String>> next() {
+            public CompletionStage<Step<String>> next() {
                 iteratorStartedBlocking.countDown();
                 return blockingFuture;
             }
@@ -139,9 +138,9 @@ class SyncIteratorAdapterTest {
         val nextCallCount = new AtomicInteger(0);
         AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
             @Override
-            public CompletionStage<Optional<String>> next() {
+            public CompletionStage<Step<String>> next() {
                 nextCallCount.incrementAndGet();
-                val failed = new CompletableFuture<Optional<String>>();
+                val failed = new CompletableFuture<Step<String>>();
                 failed.completeExceptionally(new RuntimeException("stream error"));
                 return failed;
             }
@@ -172,12 +171,12 @@ class SyncIteratorAdapterTest {
 
         AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
             @Override
-            public CompletionStage<Optional<String>> next() {
+            public CompletionStage<Step<String>> next() {
                 int i = index.getAndIncrement();
                 if (i < values.length) {
-                    return CompletableFuture.completedFuture(Optional.of(values[i]));
+                    return CompletableFuture.completedFuture(Step.value(values[i]));
                 }
-                return CompletableFuture.completedFuture(Optional.empty());
+                return CompletableFuture.completedFuture(Step.<String>done());
             }
 
             @Override
@@ -203,8 +202,8 @@ class SyncIteratorAdapterTest {
     void testEmptyIterator() {
         AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
             @Override
-            public CompletionStage<Optional<String>> next() {
-                return CompletableFuture.completedFuture(Optional.empty());
+            public CompletionStage<Step<String>> next() {
+                return CompletableFuture.completedFuture(Step.<String>done());
             }
 
             @Override
@@ -213,5 +212,45 @@ class SyncIteratorAdapterTest {
 
         val adapter = new SyncIteratorAdapter<>(asyncIterator);
         assertThat(adapter.hasNext()).isFalse();
+    }
+
+    @Test
+    void testNeedDispatchRunsThunkOnPumpThreadAndContinues() {
+        val dispatchedOnThread = new java.util.concurrent.atomic.AtomicReference<String>();
+        val dispatchedCount = new AtomicInteger(0);
+        val callCount = new AtomicInteger(0);
+
+        AsyncIterator<String> asyncIterator = new AsyncIterator<String>() {
+            @Override
+            public CompletionStage<Step<String>> next() {
+                int call = callCount.getAndIncrement();
+                switch (call) {
+                    case 0:
+                        // First call: ask pump to dispatch a thunk on its own thread
+                        return CompletableFuture.completedFuture(Step.<String>needDispatch(() -> {
+                            dispatchedOnThread.set(Thread.currentThread().getName());
+                            dispatchedCount.incrementAndGet();
+                        }));
+                    case 1:
+                        return CompletableFuture.completedFuture(Step.value("only"));
+                    default:
+                        return CompletableFuture.completedFuture(Step.<String>done());
+                }
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        val adapter = new SyncIteratorAdapter<>(asyncIterator);
+        val callerThread = Thread.currentThread().getName();
+
+        assertThat(adapter.hasNext()).isTrue();
+        assertThat(adapter.next()).isEqualTo("only");
+        assertThat(adapter.hasNext()).isFalse();
+
+        // The dispatch thunk must have run on the same thread that called hasNext().
+        assertThat(dispatchedCount.get()).isEqualTo(1);
+        assertThat(dispatchedOnThread.get()).isEqualTo(callerThread);
     }
 }

--- a/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperDatabaseSetup.java
+++ b/jdbc-core/src/testFixtures/java/com/salesforce/datacloud/jdbc/hyper/HyperDatabaseSetup.java
@@ -5,12 +5,12 @@
 package com.salesforce.datacloud.jdbc.hyper;
 
 import com.salesforce.datacloud.jdbc.protocol.async.core.AsyncStreamObserverIterator;
+import com.salesforce.datacloud.jdbc.protocol.async.core.Step;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -55,15 +55,19 @@ public final class HyperDatabaseSetup {
                 new AsyncStreamObserverIterator<>(sql, log);
         stub.executeQuery(param, iterator.getObserver());
 
-        // Drain the response stream
+        // Drain the response stream. AsyncStreamObserverIterator never emits NeedDispatch.
         try {
             while (true) {
-                CompletionStage<Optional<ExecuteQueryResponse>> next = iterator.next();
-                Optional<ExecuteQueryResponse> response =
+                CompletionStage<Step<ExecuteQueryResponse>> next = iterator.next();
+                Step<ExecuteQueryResponse> step =
                         next.toCompletableFuture().get(STATEMENT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                if (!response.isPresent()) {
+                if (step instanceof Step.Value) {
+                    continue;
+                } else if (step instanceof Step.Done) {
                     break;
                 }
+                throw new IllegalStateException("Unexpected Step subtype from AsyncStreamObserverIterator: "
+                        + step.getClass());
             }
         } catch (ExecutionException e) {
             throw new RuntimeException("Failed to execute: " + sql, e.getCause());
@@ -141,12 +145,16 @@ public final class HyperDatabaseSetup {
 
         try {
             while (true) {
-                CompletionStage<Optional<ExecuteQueryResponse>> next = iterator.next();
-                Optional<ExecuteQueryResponse> response =
+                CompletionStage<Step<ExecuteQueryResponse>> next = iterator.next();
+                Step<ExecuteQueryResponse> step =
                         next.toCompletableFuture().get(STATEMENT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                if (!response.isPresent()) {
+                if (step instanceof Step.Value) {
+                    continue;
+                } else if (step instanceof Step.Done) {
                     break;
                 }
+                throw new IllegalStateException("Unexpected Step subtype from AsyncStreamObserverIterator: "
+                        + step.getClass());
             }
         } catch (ExecutionException e) {
             throw new RuntimeException("Failed to execute: " + sql, e.getCause());


### PR DESCRIPTION
Builds on b012061. Two small follow-up changes:

1. Replace `Step.<T>retypeNeedDispatch((Step.NeedDispatch<?>) step)` with `Step.<T>forward(step)`. The unchecked cast is safe because NeedDispatch carries only a Runnable and nothing element-type-dependent; the helper centralizes and names the cast and runtime-checks it instead of letting it inline at every call site.

2. Wrap `runnable.run()` in SyncIteratorAdapter so a RuntimeException from the dispatch (e.g. a host ClientInterceptor.start() throwing) is cached into terminalError. Without this, the exception escaped the pump uncaught — subsequent hasNext() would re-drive the iterator into an unspecified state. With the catch, hasNext() re-throws the cached error on subsequent calls, matching the contract for stream-error terminal states.

All 1186 jdbc-core tests pass, including
SyncIteratorThreadLocalPropagationTest's three caller-thread assertions.