### PR TITLE
fix: don't return garbage values instead of null under arrow.enable_null_check_for_get=false

### DIFF
--- a/buildSrc/src/main/kotlin/java-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-base-conventions.gradle.kts
@@ -66,6 +66,8 @@ tasks.withType<Test>().configureEach {
     // VarCharVector/VarBinaryVector/FixedSizeBinaryVector/TimeStamp* getters skip the validity check
     // and return stale buffer bytes for null rows instead of null. Run every test task across the
     // build under that condition so the existing null-handling assertions cover the Iceberg scenario.
+    // The true case we don't need to test explicitly as everything that works with false will also
+    // work with true given the semantics of the setting.
     systemProperty("arrow.enable_null_check_for_get", "false")
 }
 

--- a/buildSrc/src/main/kotlin/java-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-base-conventions.gradle.kts
@@ -61,6 +61,12 @@ tasks.withType<Test>().configureEach {
     }
 
     jvmArgs("-Xmx1g", "-Xms512m")
+
+    // Iceberg sets -Darrow.enable_null_check_for_get=false on the JVM. With that flag off, Arrow's
+    // VarCharVector/VarBinaryVector/FixedSizeBinaryVector/TimeStamp* getters skip the validity check
+    // and return stale buffer bytes for null rows instead of null. Run every test task across the
+    // build under that condition so the existing null-handling assertions cover the Iceberg scenario.
+    systemProperty("arrow.enable_null_check_for_get", "false")
 }
 
 fun JacocoReportBase.excludeGrpc() {

--- a/jdbc-core/build.gradle.kts
+++ b/jdbc-core/build.gradle.kts
@@ -44,3 +44,11 @@ dependencies {
 tasks.named("compileJava") {
     dependsOn(":jdbc-grpc:compileJava")
 }
+
+// Iceberg sets -Darrow.enable_null_check_for_get=false on the JVM. With that flag off, Arrow's
+// VarCharVector/VarBinaryVector/FixedSizeBinaryVector .get(int) skip the validity check and return
+// stale buffer bytes for null rows instead of null. Run the test suite under that condition so
+// the existing null-handling assertions cover the Iceberg scenario.
+tasks.test {
+    systemProperty("arrow.enable_null_check_for_get", "false")
+}

--- a/jdbc-core/build.gradle.kts
+++ b/jdbc-core/build.gradle.kts
@@ -44,11 +44,3 @@ dependencies {
 tasks.named("compileJava") {
     dependsOn(":jdbc-grpc:compileJava")
 }
-
-// Iceberg sets -Darrow.enable_null_check_for_get=false on the JVM. With that flag off, Arrow's
-// VarCharVector/VarBinaryVector/FixedSizeBinaryVector .get(int) skip the validity check and return
-// stale buffer bytes for null rows instead of null. Run the test suite under that condition so
-// the existing null-handling assertions cover the Iceberg scenario.
-tasks.test {
-    systemProperty("arrow.enable_null_check_for_get", "false")
-}

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseIntVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseIntVectorAccessor.java
@@ -10,7 +10,6 @@ import com.salesforce.datacloud.jdbc.core.accessor.QueryJDBCAccessor;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
-import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import lombok.val;
 import org.apache.arrow.vector.BaseIntVector;
@@ -23,11 +22,11 @@ import org.apache.arrow.vector.types.Types.MinorType;
 
 public class BaseIntVectorAccessor extends QueryJDBCAccessor {
 
+    private final BaseIntVector vector;
     private final MinorType type;
     private final boolean isUnsigned;
     private final NumericGetter.Getter getter;
     private final NumericGetter.NumericHolder holder;
-    private final IntPredicate nullChecker;
 
     private static final String INVALID_TYPE_ERROR_RESPONSE = "Invalid Minor Type provided";
 
@@ -50,11 +49,11 @@ public class BaseIntVectorAccessor extends QueryJDBCAccessor {
     private BaseIntVectorAccessor(BaseIntVector vector, IntSupplier currentRowSupplier, boolean isUnsigned)
             throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.type = vector.getMinorType();
         this.holder = new NumericGetter.NumericHolder();
         this.getter = createGetter(vector);
         this.isUnsigned = isUnsigned;
-        this.nullChecker = vector::isNull;
     }
 
     public BaseIntVectorAccessor(UInt4Vector vector, IntSupplier currentRowSupplier) throws SQLException {
@@ -68,7 +67,7 @@ public class BaseIntVectorAccessor extends QueryJDBCAccessor {
         // (e.g. TimeStamp* in 17.0); even where current versions are validity-correct, the
         // contract is not documented, so don't rely on it.
         final int row = getCurrentRow();
-        this.wasNull = nullChecker.test(row);
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return 0;
         }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseIntVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseIntVectorAccessor.java
@@ -10,6 +10,7 @@ import com.salesforce.datacloud.jdbc.core.accessor.QueryJDBCAccessor;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import lombok.val;
 import org.apache.arrow.vector.BaseIntVector;
@@ -26,6 +27,7 @@ public class BaseIntVectorAccessor extends QueryJDBCAccessor {
     private final boolean isUnsigned;
     private final NumericGetter.Getter getter;
     private final NumericGetter.NumericHolder holder;
+    private final IntPredicate nullChecker;
 
     private static final String INVALID_TYPE_ERROR_RESPONSE = "Invalid Minor Type provided";
 
@@ -52,6 +54,7 @@ public class BaseIntVectorAccessor extends QueryJDBCAccessor {
         this.holder = new NumericGetter.NumericHolder();
         this.getter = createGetter(vector);
         this.isUnsigned = isUnsigned;
+        this.nullChecker = vector::isNull;
     }
 
     public BaseIntVectorAccessor(UInt4Vector vector, IntSupplier currentRowSupplier) throws SQLException {
@@ -60,13 +63,16 @@ public class BaseIntVectorAccessor extends QueryJDBCAccessor {
 
     @Override
     public long getLong() {
-        getter.get(getCurrentRow(), holder);
-
-        this.wasNull = holder.isSet == 0;
+        // Source wasNull from vector.isNull(int) rather than the holder field. Arrow's
+        // get(int, holder) is gated on arrow.enable_null_check_for_get for some vector types
+        // (e.g. TimeStamp* in 17.0); even where current versions are validity-correct, the
+        // contract is not documented, so don't rely on it.
+        final int row = getCurrentRow();
+        this.wasNull = nullChecker.test(row);
         if (this.wasNull) {
             return 0;
         }
-
+        getter.get(row, holder);
         return holder.value;
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseListVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseListVectorAccessor.java
@@ -32,6 +32,8 @@ public abstract class BaseListVectorAccessor extends QueryJDBCAccessor {
     }
 
     protected List<?> getListObject(VectorProvider vectorProvider) throws SQLException {
+        // ListVector/LargeListVector.getObject is validity-correct (not gated by
+        // arrow.enable_null_check_for_get), so a null return reliably indicates a null row.
         List<?> object = vectorProvider.getObject(getCurrentRow());
         this.wasNull = object == null;
         return object;

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseListVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BaseListVectorAccessor.java
@@ -32,11 +32,16 @@ public abstract class BaseListVectorAccessor extends QueryJDBCAccessor {
     }
 
     protected List<?> getListObject(VectorProvider vectorProvider) throws SQLException {
-        // ListVector/LargeListVector.getObject is validity-correct (not gated by
-        // arrow.enable_null_check_for_get), so a null return reliably indicates a null row.
-        List<?> object = vectorProvider.getObject(getCurrentRow());
-        this.wasNull = object == null;
-        return object;
+        // Source wasNull from isNull(int) rather than the getObject return value.
+        // ListVector/LargeListVector.getObject is currently validity-correct, but other
+        // vector types (e.g. TimeStamp*) gate similar paths on arrow.enable_null_check_for_get;
+        // sourcing from isNull keeps null detection independent of any future flag extension.
+        final int row = getCurrentRow();
+        this.wasNull = isNull(row);
+        if (this.wasNull) {
+            return null;
+        }
+        return vectorProvider.getObject(row);
     }
 
     protected interface VectorProvider {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BinaryVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BinaryVectorAccessor.java
@@ -6,10 +6,10 @@ package com.salesforce.datacloud.jdbc.core.accessor.impl;
 
 import com.salesforce.datacloud.jdbc.core.accessor.QueryJDBCAccessor;
 import java.nio.charset.StandardCharsets;
-import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 
 public class BinaryVectorAccessor extends QueryJDBCAccessor {
@@ -18,25 +18,25 @@ public class BinaryVectorAccessor extends QueryJDBCAccessor {
         byte[] get(int index);
     }
 
+    private final ValueVector vector;
     private final ByteArrayGetter getter;
-    private final IntPredicate nullChecker;
 
     public BinaryVectorAccessor(FixedSizeBinaryVector vector, IntSupplier currentRowSupplier) {
-        this(vector::get, vector::isNull, currentRowSupplier);
+        this(vector, vector::get, currentRowSupplier);
     }
 
     public BinaryVectorAccessor(VarBinaryVector vector, IntSupplier currentRowSupplier) {
-        this(vector::get, vector::isNull, currentRowSupplier);
+        this(vector, vector::get, currentRowSupplier);
     }
 
     public BinaryVectorAccessor(LargeVarBinaryVector vector, IntSupplier currentRowSupplier) {
-        this(vector::get, vector::isNull, currentRowSupplier);
+        this(vector, vector::get, currentRowSupplier);
     }
 
-    private BinaryVectorAccessor(ByteArrayGetter getter, IntPredicate nullChecker, IntSupplier currentRowSupplier) {
+    private BinaryVectorAccessor(ValueVector vector, ByteArrayGetter getter, IntSupplier currentRowSupplier) {
         super(currentRowSupplier);
+        this.vector = vector;
         this.getter = getter;
-        this.nullChecker = nullChecker;
     }
 
     @Override
@@ -45,7 +45,7 @@ public class BinaryVectorAccessor extends QueryJDBCAccessor {
         // (e.g. set by Iceberg on the JVM), so a null entry returns garbage rather than null.
         // Check the validity buffer explicitly via isNull(int).
         final int row = getCurrentRow();
-        this.wasNull = nullChecker.test(row);
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return null;
         }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BinaryVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BinaryVectorAccessor.java
@@ -6,6 +6,7 @@ package com.salesforce.datacloud.jdbc.core.accessor.impl;
 
 import com.salesforce.datacloud.jdbc.core.accessor.QueryJDBCAccessor;
 import java.nio.charset.StandardCharsets;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
@@ -18,30 +19,37 @@ public class BinaryVectorAccessor extends QueryJDBCAccessor {
     }
 
     private final ByteArrayGetter getter;
+    private final IntPredicate nullChecker;
 
     public BinaryVectorAccessor(FixedSizeBinaryVector vector, IntSupplier currentRowSupplier) {
-        this(vector::get, currentRowSupplier);
+        this(vector::get, vector::isNull, currentRowSupplier);
     }
 
     public BinaryVectorAccessor(VarBinaryVector vector, IntSupplier currentRowSupplier) {
-        this(vector::get, currentRowSupplier);
+        this(vector::get, vector::isNull, currentRowSupplier);
     }
 
     public BinaryVectorAccessor(LargeVarBinaryVector vector, IntSupplier currentRowSupplier) {
-        this(vector::get, currentRowSupplier);
+        this(vector::get, vector::isNull, currentRowSupplier);
     }
 
-    private BinaryVectorAccessor(ByteArrayGetter getter, IntSupplier currentRowSupplier) {
+    private BinaryVectorAccessor(ByteArrayGetter getter, IntPredicate nullChecker, IntSupplier currentRowSupplier) {
         super(currentRowSupplier);
         this.getter = getter;
+        this.nullChecker = nullChecker;
     }
 
     @Override
     public byte[] getBytes() {
-        byte[] bytes = getter.get(getCurrentRow());
-        this.wasNull = bytes == null;
-
-        return bytes;
+        // Arrow's vector.get(int) skips the isSet check when arrow.enable_null_check_for_get=false
+        // (e.g. set by Iceberg on the JVM), so a null entry returns garbage rather than null.
+        // Check the validity buffer explicitly via isNull(int).
+        final int row = getCurrentRow();
+        this.wasNull = nullChecker.test(row);
+        if (this.wasNull) {
+            return null;
+        }
+        return getter.get(row);
     }
 
     @Override

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BooleanVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/BooleanVectorAccessor.java
@@ -72,12 +72,16 @@ public class BooleanVectorAccessor extends QueryJDBCAccessor {
 
     @Override
     public long getLong() {
-        vector.get(getCurrentRow(), holder);
-        this.wasNull = holder.isSet == 0;
+        // Source wasNull from vector.isNull(int) rather than holder.isSet. Arrow's
+        // BitVector.get(int, holder) currently honors validity unconditionally, but other
+        // vector types (e.g. TimeStamp*) gate that path on arrow.enable_null_check_for_get;
+        // sourcing from isNull keeps null detection independent of any future flag extension.
+        final int row = getCurrentRow();
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return 0;
         }
-
+        vector.get(row, holder);
         return holder.value;
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArray.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DataCloudArray.java
@@ -54,11 +54,14 @@ public class DataCloudArray implements Array {
                     "End offset " + endOffset + " exceeds vector size " + dataVector.getValueCount());
         }
 
-        // Extract data into a new array
+        // Extract data into a new array. For VarChar/VarBinary/FixedSizeBinary/TimeStamp inner
+        // types, FieldVector.getObject(int) is gated by arrow.enable_null_check_for_get and
+        // returns stale buffer bytes for null rows when the flag is off (set by Iceberg). Check
+        // validity explicitly via isNull(int), which is not flag-gated.
         Object[] result = new Object[LargeMemoryUtil.checkedCastToInt(valuesCount)];
         for (int i = 0; i < valuesCount; i++) {
-            long index = startOffset + i;
-            result[i] = dataVector.getObject(LargeMemoryUtil.checkedCastToInt(index));
+            int absIndex = LargeMemoryUtil.checkedCastToInt(startOffset + i);
+            result[i] = dataVector.isNull(absIndex) ? null : dataVector.getObject(absIndex);
         }
         return result;
     }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorAccessor.java
@@ -15,7 +15,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
-import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import lombok.val;
 import org.apache.arrow.vector.DateDayVector;
@@ -24,27 +23,27 @@ import org.apache.arrow.vector.ValueVector;
 
 public class DateVectorAccessor extends QueryJDBCAccessor {
 
+    private final ValueVector vector;
     private final Getter getter;
     private final TimeUnit timeUnit;
     private final Holder holder;
-    private final IntPredicate nullChecker;
 
     private static final String INVALID_VECTOR_ERROR_RESPONSE = "Invalid Arrow vector provided";
 
     public DateVectorAccessor(DateDayVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
-        this.nullChecker = vector::isNull;
     }
 
     public DateVectorAccessor(DateMilliVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
-        this.nullChecker = vector::isNull;
     }
 
     @Override
@@ -103,7 +102,7 @@ public class DateVectorAccessor extends QueryJDBCAccessor {
         // vector types (e.g. TimeStamp*) gate that path on arrow.enable_null_check_for_get;
         // sourcing from isNull keeps null detection independent of any future flag extension.
         final int row = getCurrentRow();
-        this.wasNull = nullChecker.test(row);
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return;
         }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DateVectorAccessor.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import lombok.val;
 import org.apache.arrow.vector.DateDayVector;
@@ -26,6 +27,7 @@ public class DateVectorAccessor extends QueryJDBCAccessor {
     private final Getter getter;
     private final TimeUnit timeUnit;
     private final Holder holder;
+    private final IntPredicate nullChecker;
 
     private static final String INVALID_VECTOR_ERROR_RESPONSE = "Invalid Arrow vector provided";
 
@@ -34,6 +36,7 @@ public class DateVectorAccessor extends QueryJDBCAccessor {
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
+        this.nullChecker = vector::isNull;
     }
 
     public DateVectorAccessor(DateMilliVector vector, IntSupplier currentRowSupplier) throws SQLException {
@@ -41,6 +44,7 @@ public class DateVectorAccessor extends QueryJDBCAccessor {
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
+        this.nullChecker = vector::isNull;
     }
 
     @Override
@@ -94,8 +98,16 @@ public class DateVectorAccessor extends QueryJDBCAccessor {
     }
 
     private void fillHolder() {
-        getter.get(getCurrentRow(), holder);
-        this.wasNull = holder.isSet == 0;
+        // Source wasNull from vector.isNull(int) rather than holder.isSet. Arrow's
+        // Date*Vector.get(int, holder) currently honors validity unconditionally, but other
+        // vector types (e.g. TimeStamp*) gate that path on arrow.enable_null_check_for_get;
+        // sourcing from isNull keeps null detection independent of any future flag extension.
+        final int row = getCurrentRow();
+        this.wasNull = nullChecker.test(row);
+        if (this.wasNull) {
+            return;
+        }
+        getter.get(row, holder);
     }
 
     protected static TimeUnit getTimeUnitForVector(ValueVector vector) throws SQLException {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DecimalVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DecimalVectorAccessor.java
@@ -25,11 +25,16 @@ public class DecimalVectorAccessor extends QueryJDBCAccessor {
 
     @Override
     public BigDecimal getBigDecimal() {
-        // DecimalVector.getObject is validity-correct (not gated by arrow.enable_null_check_for_get),
-        // so a null return reliably indicates a null row even when Iceberg disables that flag.
-        final BigDecimal value = vector.getObject(getCurrentRow());
-        this.wasNull = value == null;
-        return value;
+        // Source wasNull from vector.isNull(int) rather than the getObject return value.
+        // DecimalVector.getObject is currently validity-correct, but other vector types
+        // (e.g. TimeStamp*) gate similar paths on arrow.enable_null_check_for_get; sourcing
+        // from isNull keeps null detection independent of any future flag extension.
+        final int row = getCurrentRow();
+        this.wasNull = vector.isNull(row);
+        if (this.wasNull) {
+            return null;
+        }
+        return vector.getObject(row);
     }
 
     @Override

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DecimalVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DecimalVectorAccessor.java
@@ -25,6 +25,8 @@ public class DecimalVectorAccessor extends QueryJDBCAccessor {
 
     @Override
     public BigDecimal getBigDecimal() {
+        // DecimalVector.getObject is validity-correct (not gated by arrow.enable_null_check_for_get),
+        // so a null return reliably indicates a null row even when Iceberg disables that flag.
         final BigDecimal value = vector.getObject(getCurrentRow());
         this.wasNull = value == null;
         return value;

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DoubleVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/DoubleVectorAccessor.java
@@ -33,13 +33,16 @@ public class DoubleVectorAccessor extends QueryJDBCAccessor {
 
     @Override
     public double getDouble() {
-        vector.get(getCurrentRow(), holder);
-
-        this.wasNull = holder.isSet == 0;
+        // Source wasNull from vector.isNull(int) rather than holder.isSet. Arrow's
+        // Float8Vector.get(int, holder) currently honors validity unconditionally, but other
+        // vector types (e.g. TimeStamp*) gate that path on arrow.enable_null_check_for_get;
+        // sourcing from isNull keeps null detection independent of any future flag extension.
+        final int row = getCurrentRow();
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return 0;
         }
-
+        vector.get(row, holder);
         return holder.value;
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/FloatVectorAccessor.java
@@ -33,13 +33,16 @@ public class FloatVectorAccessor extends QueryJDBCAccessor {
 
     @Override
     public float getFloat() {
-        vector.get(getCurrentRow(), holder);
-
-        this.wasNull = holder.isSet == 0;
+        // Source wasNull from vector.isNull(int) rather than holder.isSet. Arrow's
+        // Float4Vector.get(int, holder) currently honors validity unconditionally, but other
+        // vector types (e.g. TimeStamp*) gate that path on arrow.enable_null_check_for_get;
+        // sourcing from isNull keeps null detection independent of any future flag extension.
+        final int row = getCurrentRow();
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return 0;
         }
-
+        vector.get(row, holder);
         return holder.value;
     }
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampTZVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampTZVectorAccessor.java
@@ -22,7 +22,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
-import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -49,19 +48,19 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 public class TimeStampTZVectorAccessor extends QueryJDBCAccessor {
     private static final String TIMESTAMP_WITH_OFFSET_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSS xxx";
 
+    private final TimeStampVector vector;
     private final ZoneId arrowMetadataZone;
     private final TimeUnit timeUnit;
     private final TimeStampVectorGetter.Holder holder;
     private final TimeStampVectorGetter.Getter getter;
-    private final IntPredicate nullChecker;
 
     public TimeStampTZVectorAccessor(TimeStampVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.arrowMetadataZone = extractArrowMetadataZone(vector);
         this.timeUnit = getTimeUnitForVector(vector);
         this.holder = new TimeStampVectorGetter.Holder();
         this.getter = createGetter(vector);
-        this.nullChecker = vector::isNull;
     }
 
     private ZoneId resolveEffectiveZoneId(Calendar calendar) {
@@ -80,7 +79,7 @@ public class TimeStampTZVectorAccessor extends QueryJDBCAccessor {
         // entry leaves holder.isSet at its initial value (1). Check the validity buffer
         // explicitly via isNull(int), which is not gated by the flag.
         final int row = getCurrentRow();
-        this.wasNull = nullChecker.test(row);
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return null;
         }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampTZVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampTZVectorAccessor.java
@@ -22,6 +22,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -52,6 +53,7 @@ public class TimeStampTZVectorAccessor extends QueryJDBCAccessor {
     private final TimeUnit timeUnit;
     private final TimeStampVectorGetter.Holder holder;
     private final TimeStampVectorGetter.Getter getter;
+    private final IntPredicate nullChecker;
 
     public TimeStampTZVectorAccessor(TimeStampVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
@@ -59,6 +61,7 @@ public class TimeStampTZVectorAccessor extends QueryJDBCAccessor {
         this.timeUnit = getTimeUnitForVector(vector);
         this.holder = new TimeStampVectorGetter.Holder();
         this.getter = createGetter(vector);
+        this.nullChecker = vector::isNull;
     }
 
     private ZoneId resolveEffectiveZoneId(Calendar calendar) {
@@ -72,12 +75,16 @@ public class TimeStampTZVectorAccessor extends QueryJDBCAccessor {
     }
 
     private Instant getInstant() {
-        getter.get(getCurrentRow(), holder);
-        this.wasNull = holder.isSet == 0;
-
+        // Arrow's TimeStampVector.get(int, holder) skips populating holder.isSet when
+        // arrow.enable_null_check_for_get=false (e.g. set by Iceberg on the JVM), so a null
+        // entry leaves holder.isSet at its initial value (1). Check the validity buffer
+        // explicitly via isNull(int), which is not gated by the flag.
+        final int row = getCurrentRow();
+        this.wasNull = nullChecker.test(row);
         if (this.wasNull) {
             return null;
         }
+        getter.get(row, holder);
 
         long value = holder.value;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorAccessor.java
@@ -20,6 +20,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import lombok.val;
 import org.apache.arrow.vector.TimeStampVector;
@@ -53,12 +54,14 @@ public class TimeStampVectorAccessor extends QueryJDBCAccessor {
     private final TimeUnit timeUnit;
     private final TimeStampVectorGetter.Holder holder;
     private final TimeStampVectorGetter.Getter getter;
+    private final IntPredicate nullChecker;
 
     public TimeStampVectorAccessor(TimeStampVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
         this.timeUnit = getTimeUnitForVector(vector);
         this.holder = new TimeStampVectorGetter.Holder();
         this.getter = createGetter(vector);
+        this.nullChecker = vector::isNull;
     }
 
     /**
@@ -66,12 +69,16 @@ public class TimeStampVectorAccessor extends QueryJDBCAccessor {
      * so this instant represents the literal treated as UTC.
      */
     Instant getInstant() {
-        getter.get(getCurrentRow(), holder);
-        this.wasNull = holder.isSet == 0;
-
+        // Arrow's TimeStampVector.get(int, holder) skips populating holder.isSet when
+        // arrow.enable_null_check_for_get=false (e.g. set by Iceberg on the JVM), so a null
+        // entry leaves holder.isSet at its initial value (1). Check the validity buffer
+        // explicitly via isNull(int), which is not gated by the flag.
+        final int row = getCurrentRow();
+        this.wasNull = nullChecker.test(row);
         if (this.wasNull) {
             return null;
         }
+        getter.get(row, holder);
 
         long value = holder.value;
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeStampVectorAccessor.java
@@ -20,7 +20,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
-import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import lombok.val;
 import org.apache.arrow.vector.TimeStampVector;
@@ -51,17 +50,17 @@ public class TimeStampVectorAccessor extends QueryJDBCAccessor {
     private static final ZoneId UTC = ZoneId.of("UTC");
     static final String INVALID_UNIT_ERROR_RESPONSE = "Invalid Arrow time unit";
 
+    private final TimeStampVector vector;
     private final TimeUnit timeUnit;
     private final TimeStampVectorGetter.Holder holder;
     private final TimeStampVectorGetter.Getter getter;
-    private final IntPredicate nullChecker;
 
     public TimeStampVectorAccessor(TimeStampVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.timeUnit = getTimeUnitForVector(vector);
         this.holder = new TimeStampVectorGetter.Holder();
         this.getter = createGetter(vector);
-        this.nullChecker = vector::isNull;
     }
 
     /**
@@ -74,7 +73,7 @@ public class TimeStampVectorAccessor extends QueryJDBCAccessor {
         // entry leaves holder.isSet at its initial value (1). Check the validity buffer
         // explicitly via isNull(int), which is not gated by the flag.
         final int row = getCurrentRow();
-        this.wasNull = nullChecker.test(row);
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return null;
         }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorAccessor.java
@@ -16,6 +16,7 @@ import java.sql.Timestamp;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import lombok.val;
 import org.apache.arrow.vector.TimeMicroVector;
@@ -29,6 +30,7 @@ public class TimeVectorAccessor extends QueryJDBCAccessor {
     private final Getter getter;
     private final TimeUnit timeUnit;
     private final Holder holder;
+    private final IntPredicate nullChecker;
 
     private static final String INVALID_VECTOR_ERROR_RESPONSE = "Unsupported Timestamp vector type provided";
 
@@ -37,6 +39,7 @@ public class TimeVectorAccessor extends QueryJDBCAccessor {
         this.holder = new TimeVectorGetter.Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
+        this.nullChecker = vector::isNull;
     }
 
     public TimeVectorAccessor(TimeMicroVector vector, IntSupplier currentRowSupplier) throws SQLException {
@@ -44,6 +47,7 @@ public class TimeVectorAccessor extends QueryJDBCAccessor {
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
+        this.nullChecker = vector::isNull;
     }
 
     public TimeVectorAccessor(TimeMilliVector vector, IntSupplier currentRowSupplier) throws SQLException {
@@ -51,6 +55,7 @@ public class TimeVectorAccessor extends QueryJDBCAccessor {
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
+        this.nullChecker = vector::isNull;
     }
 
     public TimeVectorAccessor(TimeSecVector vector, IntSupplier currentRowSupplier) throws SQLException {
@@ -58,6 +63,7 @@ public class TimeVectorAccessor extends QueryJDBCAccessor {
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
+        this.nullChecker = vector::isNull;
     }
 
     @Override
@@ -88,8 +94,16 @@ public class TimeVectorAccessor extends QueryJDBCAccessor {
     }
 
     private void fillHolder() {
-        getter.get(getCurrentRow(), holder);
-        this.wasNull = holder.isSet == 0;
+        // Source wasNull from vector.isNull(int) rather than holder.isSet. Arrow's
+        // Time*Vector.get(int, holder) currently honors validity unconditionally, but other
+        // vector types (e.g. TimeStamp*) gate that path on arrow.enable_null_check_for_get;
+        // sourcing from isNull keeps null detection independent of any future flag extension.
+        final int row = getCurrentRow();
+        this.wasNull = nullChecker.test(row);
+        if (this.wasNull) {
+            return;
+        }
+        getter.get(row, holder);
     }
 
     /**

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/TimeVectorAccessor.java
@@ -16,7 +16,6 @@ import java.sql.Timestamp;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
-import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import lombok.val;
 import org.apache.arrow.vector.TimeMicroVector;
@@ -27,43 +26,43 @@ import org.apache.arrow.vector.ValueVector;
 
 public class TimeVectorAccessor extends QueryJDBCAccessor {
 
+    private final ValueVector vector;
     private final Getter getter;
     private final TimeUnit timeUnit;
     private final Holder holder;
-    private final IntPredicate nullChecker;
 
     private static final String INVALID_VECTOR_ERROR_RESPONSE = "Unsupported Timestamp vector type provided";
 
     public TimeVectorAccessor(TimeNanoVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.holder = new TimeVectorGetter.Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
-        this.nullChecker = vector::isNull;
     }
 
     public TimeVectorAccessor(TimeMicroVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
-        this.nullChecker = vector::isNull;
     }
 
     public TimeVectorAccessor(TimeMilliVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
-        this.nullChecker = vector::isNull;
     }
 
     public TimeVectorAccessor(TimeSecVector vector, IntSupplier currentRowSupplier) throws SQLException {
         super(currentRowSupplier);
+        this.vector = vector;
         this.holder = new Holder();
         this.getter = createGetter(vector);
         this.timeUnit = getTimeUnitForVector(vector);
-        this.nullChecker = vector::isNull;
     }
 
     @Override
@@ -99,7 +98,7 @@ public class TimeVectorAccessor extends QueryJDBCAccessor {
         // vector types (e.g. TimeStamp*) gate that path on arrow.enable_null_check_for_get;
         // sourcing from isNull keeps null detection independent of any future flag extension.
         final int row = getCurrentRow();
-        this.wasNull = nullChecker.test(row);
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return;
         }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessor.java
@@ -6,6 +6,7 @@ package com.salesforce.datacloud.jdbc.core.accessor.impl;
 
 import com.salesforce.datacloud.jdbc.core.accessor.QueryJDBCAccessor;
 import java.nio.charset.StandardCharsets;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -18,18 +19,20 @@ public class VarCharVectorAccessor extends QueryJDBCAccessor {
     }
 
     private final Getter getter;
+    private final IntPredicate nullChecker;
 
     public VarCharVectorAccessor(VarCharVector vector, IntSupplier currenRowSupplier) {
-        this(vector::get, currenRowSupplier);
+        this(vector::get, vector::isNull, currenRowSupplier);
     }
 
     public VarCharVectorAccessor(LargeVarCharVector vector, IntSupplier currenRowSupplier) {
-        this(vector::get, currenRowSupplier);
+        this(vector::get, vector::isNull, currenRowSupplier);
     }
 
-    VarCharVectorAccessor(Getter getter, IntSupplier currentRowSupplier) {
+    VarCharVectorAccessor(Getter getter, IntPredicate nullChecker, IntSupplier currentRowSupplier) {
         super(currentRowSupplier);
         this.getter = getter;
+        this.nullChecker = nullChecker;
     }
 
     @Override
@@ -39,9 +42,15 @@ public class VarCharVectorAccessor extends QueryJDBCAccessor {
 
     @Override
     public byte[] getBytes() {
-        final byte[] bytes = this.getter.get(getCurrentRow());
-        this.wasNull = bytes == null;
-        return this.getter.get(getCurrentRow());
+        // Arrow's vector.get(int) skips the isSet check when arrow.enable_null_check_for_get=false
+        // (e.g. set by Iceberg on the JVM), so a null entry returns an empty byte[] rather than null.
+        // Check the validity buffer explicitly via isNull(int).
+        final int row = getCurrentRow();
+        this.wasNull = nullChecker.test(row);
+        if (this.wasNull) {
+            return null;
+        }
+        return this.getter.get(row);
     }
 
     @Override

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessor.java
@@ -43,8 +43,8 @@ public class VarCharVectorAccessor extends QueryJDBCAccessor {
     @Override
     public byte[] getBytes() {
         // Arrow's vector.get(int) skips the isSet check when arrow.enable_null_check_for_get=false
-        // (e.g. set by Iceberg on the JVM), so a null entry returns an empty byte[] rather than null.
-        // Check the validity buffer explicitly via isNull(int).
+        // (e.g. set by Iceberg on the JVM), so a null entry returns stale buffer bytes (often empty,
+        // but not guaranteed) rather than null. Check the validity buffer explicitly via isNull(int).
         final int row = getCurrentRow();
         this.wasNull = vector.isNull(row);
         if (this.wasNull) {

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessor.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/accessor/impl/VarCharVectorAccessor.java
@@ -6,9 +6,9 @@ package com.salesforce.datacloud.jdbc.core.accessor.impl;
 
 import com.salesforce.datacloud.jdbc.core.accessor.QueryJDBCAccessor;
 import java.nio.charset.StandardCharsets;
-import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
 import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
 
 public class VarCharVectorAccessor extends QueryJDBCAccessor {
@@ -18,21 +18,21 @@ public class VarCharVectorAccessor extends QueryJDBCAccessor {
         byte[] get(int index);
     }
 
+    private final ValueVector vector;
     private final Getter getter;
-    private final IntPredicate nullChecker;
 
     public VarCharVectorAccessor(VarCharVector vector, IntSupplier currenRowSupplier) {
-        this(vector::get, vector::isNull, currenRowSupplier);
+        this(vector, vector::get, currenRowSupplier);
     }
 
     public VarCharVectorAccessor(LargeVarCharVector vector, IntSupplier currenRowSupplier) {
-        this(vector::get, vector::isNull, currenRowSupplier);
+        this(vector, vector::get, currenRowSupplier);
     }
 
-    VarCharVectorAccessor(Getter getter, IntPredicate nullChecker, IntSupplier currentRowSupplier) {
+    VarCharVectorAccessor(ValueVector vector, Getter getter, IntSupplier currentRowSupplier) {
         super(currentRowSupplier);
+        this.vector = vector;
         this.getter = getter;
-        this.nullChecker = nullChecker;
     }
 
     @Override
@@ -46,11 +46,11 @@ public class VarCharVectorAccessor extends QueryJDBCAccessor {
         // (e.g. set by Iceberg on the JVM), so a null entry returns an empty byte[] rather than null.
         // Check the validity buffer explicitly via isNull(int).
         final int row = getCurrentRow();
-        this.wasNull = nullChecker.test(row);
+        this.wasNull = vector.isNull(row);
         if (this.wasNull) {
             return null;
         }
-        return this.getter.get(row);
+        return getter.get(row);
     }
 
     @Override


### PR DESCRIPTION
## Summary

When Iceberg is on the classpath it sets `-Darrow.enable_null_check_for_get=false` on the JVM for performance. With that flag off, Arrow's `VarCharVector`, `VarBinaryVector`, `FixedSizeBinaryVector`, and `TimeStamp*Vector` getters skip the validity check and return stale buffer bytes (often empty, but not guaranteed) for null rows instead of `null`. A SQL NULL surfaced as `""` / `0` / a sentinel timestamp, and `wasNull()` returned `false`. For example `SELECT NULL::timestamp` / `timestamptz` returned `1970-01-01T00:00:00Z` (or the `4714-12-31` sentinel for `getObject`); now - with the fix -returns `null`.

Behavior under the flag's default (`true`) is unchanged.

## Approach

Every accessor sources `wasNull` from `vector.isNull(int)` rather than from `holder.isSet` or a return-value sniff. `isNull` reads the validity buffer directly via `BitVectorHelper` — there's no per-row work for the flag to disable, so it is flag-proof.

This is a wider migration than the bug strictly requires. The flag-gating is currently only on VarChar/Binary/FixedSizeBinary/TimeStamp* in Arrow 17, but Arrow's contract ("skip the validity check on get") authorizes future minor versions to extend the gating to any vector type. Sourcing `wasNull` uniformly from `isNull` insulates us from any Arrow upgrade — including upgrades in consumer setups, where a tripwire test in this repository wouldn't fire.

`DataCloudArray.extractDataFromVector` had the same bug for VarChar/Binary/TimeStamp inner element types; it now consults `dataVector.isNull(absIndex)` before each `getObject` call.

## Test plan

`arrow.enable_null_check_for_get=false` is set in `buildSrc/src/main/kotlin/java-base-conventions.gradle.kts` `tasks.withType<Test>().configureEach`, so every test task across the build runs under the Iceberg scenario.

- Verified existing coverage catches the bug: with only the gradle flag and accessor sources reverted to `main`, **25 tests fail across 10 classes** — `JDBCReferenceTest`, `VarCharVectorAccessorTest`, `BinaryVectorAccessorTest`, `TimeStampVectorAccessorTest`, `DataCloudArrayTest`, `TimeZoneIntegrationTest`, plus metadata/connection paths asserting `expected: null but was: ""`.
