### PR TITLE
ci: unpin JReleaser and migrate signing config to signing.pgp.*

### DIFF
--- a/.github/workflows/reusable-build-publish.yml
+++ b/.github/workflows/reusable-build-publish.yml
@@ -189,8 +189,6 @@ jobs:
           echo "resolved_version=$RESOLVED_VERSION" >> $GITHUB_OUTPUT
       - name: Publish to Maven Central
         uses: jreleaser/release-action@v2
-        with:
-          version: 1.19.0
         env:
           JRELEASER_PROJECT_VERSION: ${{ steps.resolve_version.outputs.resolved_version }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.publish_user }}

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -23,8 +23,9 @@ project:
 
 signing:
   active: ALWAYS
-  armored: true
-  verify: false
+  pgp:
+    armored: true
+    verify: false
 
 deploy:
   maven:


### PR DESCRIPTION
The version: 1.19.0 pin (https://github.com/forcedotcom/datacloud-jdbc/commit/15d078449847001944fec577e188925d68c225eb) was a workaround for JReleaser 1.20.0's
strict pre-flight validation of JRELEASER_GPG_PUBLIC_KEY rejecting our
malformed signing_pub repo secret. The secret has been re-pasted with
proper PGP armor and Unix line endings, so the pin is no longer needed.

signing.armored / signing.verify were deprecated in JReleaser 1.22.0 in
favor of signing.pgp.armored / signing.pgp.verify. Migrating now removes
the deprecation warnings under JReleaser 1.24.0 (now pulled by 'latest').

Verified locally with full-release --dry-run on JReleaser 1.24.0:
all 40+ artifacts signed, deployer bundle assembled, upload skipped.

Resolves W-19797346.