### PR TITLE
fix(ci): bump codecov-action v5 -> v6 for keybase GPG migration

### DIFF
--- a/.github/workflows/reusable-build-publish.yml
+++ b/.github/workflows/reusable-build-publish.yml
@@ -107,7 +107,7 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
       - name: Upload coverage reports to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
 ## Summary
  - Bumps `codecov/codecov-action` from `@v5` to `@v6`. One-line fix.

  ## Background
  On 2026-06-07, Codecov [rotated](https://github.com/codecov/codecov-action/issues/1956) their keybase account from `keybase.io/codecovsecurity` to `keybase.io/codecovsecops` and bricked the old account. The codecov-action@v5 binary's GPG
  verification step now fails on every run with:

  gpg: using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
  gpg: Can't check signature: No public key
  ==> Could not verify signature. Please contact Codecov if problem continues

  Because we have `fail_ci_if_error: true`, every PR build now fails at the Codecov upload step. This is unrelated to anything in this repo — it's a global Codecov regression.

  Codecov published `v6.0.2` as a copy of `v7.0.0` specifically to ease this migration without forcing the major-version semantic break.

  ## Reference
  - https://github.com/codecov/codecov-action/issues/1956