### PR TITLE
chore(codeowners): set valid GUSINFO for OSPO compliance

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:CDP Query Service (US),D360 Query - Immutable
 * datacloud-query-connector-owners@salesforce.com


### PR DESCRIPTION
Point the CODEOWNERS #GUSINFO line at the repo's owning GUS Scrum Team and Product Tag, per OSPO policy. Both records are Active in GUS.

Scrum Team:  CDP Query Service (US)
Product Tag: D360 Query - Immutable