### PR TITLE
feat(auth): support OAuth 2.0 client credentials flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use `com.salesforce.datacloud.jdbc.DataCloudJDBCDriver` as the driver class name
 
 ### Authentication
 
-We support three of the [OAuth authorization flows][oauth authorization flows] provided by Salesforce.
+We support four of the [OAuth authorization flows][oauth authorization flows] provided by Salesforce.
 All of these flows require a connected app be configured for the driver to authenticate as, see the documentation here: [connected app overview][connected app overview].
 Set the following properties appropriately to establish a connection with your chosen OAuth authorization flow:
 
@@ -112,6 +112,18 @@ The documentation for refresh token authentication can be found [here][refresh t
 ```java
 Properties properties = new Properties();
 properties.put("refreshToken", "${refreshToken}");
+properties.put("clientId", "${clientId}");
+properties.put("clientSecret", "${clientSecret}");
+```
+
+#### client credentials authentication:
+
+The documentation for client credentials authentication can be found [here][client credentials flow].
+
+This flow authenticates as the connected app's run-as user with no interactive user context, so set only `clientId` and `clientSecret`:
+
+```java
+Properties properties = new Properties();
 properties.put("clientId", "${clientId}");
 properties.put("clientSecret", "${clientSecret}");
 ```
@@ -219,5 +231,6 @@ public static void executeQuery() throws ClassNotFoundException, SQLException {
 [username flow]: https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_username_password_flow.htm&type=5
 [jwt flow]: https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm&type=5
 [refresh token flow]: https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_refresh_token_flow.htm&type=5
+[client credentials flow]: https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_client_credentials_flow.htm&type=5
 [connection settings]: https://tableau.github.io/hyper-db/docs/hyper-api/connection#connection-settings
 [connected app overview]: https://help.salesforce.com/s/articleView?id=sf.connected_app_overview.htm&type=5

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProvider.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProvider.java
@@ -146,6 +146,11 @@ public class DataCloudTokenProvider {
                 builder.bodyEntry("refresh_token", settings.getRefreshToken());
                 builder.bodyEntry("client_secret", settings.getClientSecret());
                 break;
+            case CLIENT_CREDENTIALS:
+                // https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_client_credentials_flow.htm&type=5
+                builder.bodyEntry("grant_type", "client_credentials");
+                builder.bodyEntry("client_secret", settings.getClientSecret());
+                break;
         }
 
         return builder.build();

--- a/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/SalesforceAuthProperties.java
+++ b/jdbc-http/src/main/java/com/salesforce/datacloud/jdbc/auth/SalesforceAuthProperties.java
@@ -30,14 +30,14 @@ import lombok.extern.slf4j.Slf4j;
  *
  * Configures authentication mode, credentials, and connection settings.
  *
- * To create a SalesforceAuthProperties instance, in a type-safe way, use
- * the `builderUsingPassword`, `builderUsingPrivateKey`, or `builderUsingRefreshToken`.
+ * The authentication mode is auto-detected from the properties that are present
+ * (see {@link #ofDestructive(URI, Properties)}).
  *
  * Accepts the following properties:
  * - userName: Username for password/private key authentication
  * - password: Password for password authentication
  * - privateKey: Private key for JWT authentication
- * - clientSecret: OAuth client secret (required for PASSWORD and REFRESH_TOKEN modes, not allowed for PRIVATE_KEY/JWT mode)
+ * - clientSecret: OAuth client secret (required for PASSWORD, REFRESH_TOKEN, and CLIENT_CREDENTIALS modes, not allowed for PRIVATE_KEY/JWT mode)
  * - clientId: OAuth client ID (required)
  * - dataspace: Data space identifier, default is null
  * - refreshToken: Refresh token for token-based authentication
@@ -49,7 +49,8 @@ public class SalesforceAuthProperties {
     public enum AuthenticationMode {
         PASSWORD,
         PRIVATE_KEY,
-        REFRESH_TOKEN
+        REFRESH_TOKEN,
+        CLIENT_CREDENTIALS
     }
 
     static final String AUTH_USER_NAME = "userName";
@@ -130,9 +131,14 @@ public class SalesforceAuthProperties {
             // We still accept an optional userName. This might show up
             // in the `DatabaseMetadata.getUserName` call.
             builder.userName(takeOptional(props, AUTH_USER_NAME).orElse(null));
+        } else if (props.containsKey(AUTH_CLIENT_SECRET)) {
+            // https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_client_credentials_flow.htm&type=5
+            // Client credentials flow uses only clientId + clientSecret; there is no user identity.
+            builder.authenticationMode(AuthenticationMode.CLIENT_CREDENTIALS);
+            builder.clientSecret(takeRequired(props, AUTH_CLIENT_SECRET));
         } else {
             throw new SQLException(
-                    "Properties must contain either (userName + password), (userName + privateKey), or refreshToken",
+                    "Properties must contain either (userName + password), (userName + privateKey), refreshToken, or clientSecret",
                     "28000");
         }
 
@@ -172,6 +178,9 @@ public class SalesforceAuthProperties {
                 break;
             case REFRESH_TOKEN:
                 props.setProperty(AUTH_REFRESH_TOKEN, refreshToken);
+                props.setProperty(AUTH_CLIENT_SECRET, clientSecret);
+                break;
+            case CLIENT_CREDENTIALS:
                 props.setProperty(AUTH_CLIENT_SECRET, clientSecret);
                 break;
         }

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProviderTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/DataCloudTokenProviderTest.java
@@ -59,6 +59,13 @@ class DataCloudTokenProviderTest {
         return properties;
     }
 
+    static Properties propertiesForClientCredentials(String clientId, String clientSecret) {
+        val properties = new Properties();
+        properties.setProperty(SalesforceAuthProperties.AUTH_CLIENT_ID, clientId);
+        properties.setProperty(SalesforceAuthProperties.AUTH_CLIENT_SECRET, clientSecret);
+        return properties;
+    }
+
     // Valid RSA private key in PEM format for testing
     private static final String FAKE_PRIVATE_KEY = SalesforceAuthPropertiesTest.FAKE_PRIVATE_KEY;
 
@@ -462,6 +469,82 @@ class DataCloudTokenProviderTest {
             assertThat(actual.getAccessToken()).as("access token").isEqualTo(expected.getAccessToken());
             assertThat(actual.getTenantUrl()).as("tenant url").isEqualTo(expected.getTenantUrl());
             assertThat(actual.getTenantId()).as("tenant id").isEqualTo(FAKE_TENANT_ID);
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    void testClientCredentialsAuthenticationSuccess() {
+        val mapper = new ObjectMapper();
+        val clientId = UUID.randomUUID().toString();
+        val clientSecret = UUID.randomUUID().toString();
+        val properties = propertiesForClientCredentials(clientId, clientSecret);
+        val oAuthTokenResponse = new OAuthTokenResponse();
+        val accessToken = UUID.randomUUID().toString();
+        oAuthTokenResponse.setToken(accessToken);
+
+        try (val server = new MockWebServer()) {
+            server.start();
+            oAuthTokenResponse.setInstanceUrl(server.url("").toString());
+            server.enqueue(new MockResponse().setBody(mapper.writeValueAsString(oAuthTokenResponse)));
+
+            val loginUrl = server.url("").uri();
+            HttpClientProperties clientProperties = HttpClientProperties.ofDestructive(properties);
+            SalesforceAuthProperties authProperties = SalesforceAuthProperties.ofDestructive(loginUrl, properties);
+            val actual =
+                    DataCloudTokenProvider.of(clientProperties, authProperties).getOAuthToken();
+
+            assertThat(actual.getToken()).as("access token").isEqualTo(accessToken);
+
+            val request = server.takeRequest();
+            val body = request.getBody().readUtf8();
+            softly.assertThat(body).as("grant_type").contains("grant_type=client_credentials");
+            softly.assertThat(body).as("client_id").contains("client_id=" + clientId);
+            softly.assertThat(body).as("client_secret").contains("client_secret=" + clientSecret);
+            // Client credentials carries no user identity - guard against accidentally leaking one.
+            softly.assertThat(body).as("no username").doesNotContain("username=");
+            softly.assertThat(body).as("no password").doesNotContain("password=");
+            softly.assertThat(body).as("no refresh_token").doesNotContain("refresh_token=");
+        }
+    }
+
+    // Also includes the token exchange flow, with a dataspace to confirm the shared exchange leg is reached.
+    @SneakyThrows
+    @Test
+    void testClientCredentialsBasedDataCloudTokenFlow() {
+        val mapper = new ObjectMapper();
+        val dataspace = UUID.randomUUID().toString();
+        val properties = propertiesForClientCredentials("clientId", "clientSecret");
+        properties.put(SalesforceAuthProperties.AUTH_DATASPACE, dataspace);
+        val oAuthTokenResponse = new OAuthTokenResponse();
+        oAuthTokenResponse.setToken(UUID.randomUUID().toString());
+
+        try (val server = new MockWebServer()) {
+            server.start();
+            oAuthTokenResponse.setInstanceUrl(server.url("").toString());
+            val dataCloudTokenResponse = new DataCloudTokenResponse();
+            dataCloudTokenResponse.setTokenType(UUID.randomUUID().toString());
+            dataCloudTokenResponse.setExpiresIn(60000);
+            dataCloudTokenResponse.setToken(FAKE_TOKEN);
+            dataCloudTokenResponse.setInstanceUrl(server.url("").toString());
+            val expected = DataCloudToken.of(dataCloudTokenResponse);
+
+            server.enqueue(new MockResponse().setBody(mapper.writeValueAsString(oAuthTokenResponse)));
+            server.enqueue(new MockResponse().setBody(mapper.writeValueAsString(dataCloudTokenResponse)));
+
+            val loginUrl = server.url("").uri();
+            HttpClientProperties clientProperties = HttpClientProperties.ofDestructive(properties);
+            SalesforceAuthProperties authProperties = SalesforceAuthProperties.ofDestructive(loginUrl, properties);
+
+            val processor = DataCloudTokenProvider.of(clientProperties, authProperties);
+            val actual = processor.getDataCloudToken();
+
+            assertThat(actual.getAccessToken()).as("access token").isEqualTo(expected.getAccessToken());
+            assertThat(actual.getTenantUrl()).as("tenant url").isEqualTo(expected.getTenantUrl());
+            assertThat(actual.getTenantId()).as("tenant id").isEqualTo(FAKE_TENANT_ID);
+            assertThat(processor.getLakehouseName())
+                    .as("lakehouse")
+                    .isEqualTo("lakehouse:" + FAKE_TENANT_ID + ";" + dataspace);
         }
     }
 

--- a/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/SalesforceAuthPropertiesTest.java
+++ b/jdbc-http/src/test/java/com/salesforce/datacloud/jdbc/auth/SalesforceAuthPropertiesTest.java
@@ -141,6 +141,50 @@ class SalesforceAuthPropertiesTest {
     }
 
     @Test
+    void parsesClientCredentialsAuthenticationProperties() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("clientId", TEST_CLIENT_ID);
+        props.setProperty("clientSecret", TEST_CLIENT_SECRET);
+        props.setProperty("dataspace", TEST_DATASPACE);
+
+        SalesforceAuthProperties authProps = SalesforceAuthProperties.ofDestructive(TEST_LOGIN_URL, props);
+
+        assertThat(authProps.getLoginUrl()).isEqualTo(TEST_LOGIN_URL);
+        assertThat(authProps.getAuthenticationMode())
+                .isEqualTo(SalesforceAuthProperties.AuthenticationMode.CLIENT_CREDENTIALS);
+        assertThat(authProps.getClientId()).isEqualTo(TEST_CLIENT_ID);
+        assertThat(authProps.getClientSecret()).isEqualTo(TEST_CLIENT_SECRET);
+        assertThat(authProps.getDataspace()).isEqualTo(TEST_DATASPACE);
+        assertThat(authProps.getUserName()).isNull();
+    }
+
+    @Test
+    void toPropertiesRoundtripClientCredentialsAuthentication() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("clientId", TEST_CLIENT_ID);
+        props.setProperty("clientSecret", TEST_CLIENT_SECRET);
+        props.setProperty("dataspace", TEST_DATASPACE);
+
+        Properties originalProps = (Properties) props.clone();
+        SalesforceAuthProperties authProps = SalesforceAuthProperties.ofDestructive(TEST_LOGIN_URL, props);
+        Properties roundtripProps = authProps.toProperties();
+
+        assertThat(roundtripProps).isEqualTo(originalProps);
+    }
+
+    @Test
+    void rejectsUserNameMixedWithClientCredentials() {
+        Properties props = new Properties();
+        props.setProperty("clientId", TEST_CLIENT_ID);
+        props.setProperty("clientSecret", TEST_CLIENT_SECRET);
+        props.setProperty("userName", TEST_USER_NAME); // no password -> not PASSWORD mode
+
+        assertThatThrownBy(() -> SalesforceAuthProperties.ofDestructive(TEST_LOGIN_URL, props))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("Properties from different authentication modes cannot be mixed");
+    }
+
+    @Test
     void parsesPropertiesWithoutDataspace() throws SQLException {
         Properties props = new Properties();
         props.setProperty("clientId", TEST_CLIENT_ID);
@@ -203,13 +247,12 @@ class SalesforceAuthPropertiesTest {
     void rejectsInvalidAuthenticationMode() {
         Properties props = new Properties();
         props.setProperty("clientId", TEST_CLIENT_ID);
-        props.setProperty("clientSecret", TEST_CLIENT_SECRET);
-        // Missing all authentication credentials
+        // Missing all authentication credentials (no clientSecret, password, privateKey, or refreshToken)
 
         assertThatThrownBy(() -> SalesforceAuthProperties.ofDestructive(TEST_LOGIN_URL, props))
                 .isInstanceOf(SQLException.class)
                 .hasMessageContaining(
-                        "Properties must contain either (userName + password), (userName + privateKey), or refreshToken");
+                        "Properties must contain either (userName + password), (userName + privateKey), refreshToken, or clientSecret");
     }
 
     @Test


### PR DESCRIPTION
Add CLIENT_CREDENTIALS as a fourth authentication mode alongside password, JWT/private-key, and refresh-token. The mode is auto-detected when only clientId + clientSecret are supplied (no user identity).

Leg 1 posts grant_type=client_credentials with client_id and client_secret; the CDP token exchange (leg 2), caching, and gRPC path are mode-agnostic and unchanged.

Ref: https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_client_credentials_flow.htm&type=5