### PR TITLE
feat: support named prepared statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ com.salesforce.datacloud.jdbc.DataCloudJDBCDriver
 > This supported API includes:
 > 1. Any construct available through the JDBC specification we have implemented
 > 2. The DataCloudQueryStatus class
-> 3. The public methods in DataCloudConnection, DataCloudStatement, DataCloudResultSet, and DataCloudPreparedStatement -- note that these will be refactored to be interfaces that will make the API more obvious in the near future
+> 3. The public methods in DataCloudConnection, DataCloudStatement, DataCloudResultSet, DataCloudPreparedStatement, and DataCloudNamedPreparedStatement -- note that these will be refactored to be interfaces that will make the API more obvious in the near future
 >
 > Usage of any other public classes or methods not listed above should be considered relatively unsafe, though we will strive to not make changes and will use semantic versioning from 1.0.0 and on.
 
@@ -147,6 +147,25 @@ This section describes details around potential pitfalls / ambiguities related t
 - The standard offers two types for fixed point decimals (`NUMERIC` and `DECIMAL`), this driver uses `DECIMAL` to represent such values
 - The JDBC standard describes that `getObject` for a `SHORT` should return an `Integer`. Due to a current limitation we for now return a `Short` object. This will likely be fixed in a future version of the JDBC driver.
 - The query timeout enforcement is done on the server side for both normal as well as async execution. To provide a safety net with regards to network problems the driver locally also does a delayed enforcement for normal query executions. The default delay is `5` seconds - which typically shouldn't be relevant as in normal circumstances the server will enforce the timeout. The local enforcement delay can be configured through the `queryTimeoutLocalEnforcementDelay` property
+
+### Named parameters
+
+`DataCloudConnection` supports Hyper's native `:name` parameters through `prepareNamedStatement`:
+
+```java
+try (DataCloudNamedPreparedStatement statement =
+        connection.prepareNamedStatement("SELECT :minimum + :increment")) {
+    statement.setInt("minimum", 40);
+    statement.setInt("increment", 2);
+
+    try (ResultSet result = statement.executeQuery()) {
+        result.next();
+        int value = result.getInt(1); // 42
+    }
+}
+```
+
+Use `Connection.prepareStatement` for standard JDBC positional `?` parameters.
 
 ### Timestamp handling
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudConnection.java
@@ -187,6 +187,14 @@ public class DataCloudConnection implements Connection {
     }
 
     /**
+     * Creates a prepared statement for SQL containing named parameters such as
+     * {@code SELECT :accountId}.
+     */
+    public DataCloudNamedPreparedStatement prepareNamedStatement(String sql) {
+        return new DataCloudNamedPreparedStatement(this, sql);
+    }
+
+    /**
      * Retrieves a collection of rows for the specified query within the specified range.
      * <b>Important:</b> Before calling this method, you must ensure that the requested row range is available on the server.
      * Use {@link #waitFor(String, Duration, Predicate)} with an appropriate predicate to wait until the desired number of rows

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudNamedPreparedStatement.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudNamedPreparedStatement.java
@@ -1,0 +1,142 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import com.salesforce.datacloud.jdbc.protocol.data.HyperType;
+import com.salesforce.datacloud.jdbc.protocol.data.ParameterBinding;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import salesforce.cdp.hyperdb.v1.QueryParam;
+
+/**
+ * A Hyper specific prepared statement for named parameters such as {@code :account_id}.
+ * Create instances with {@link DataCloudConnection#prepareNamedStatement(String)} and execute the
+ * SQL supplied there using {@link #executeQuery()}, {@link #execute()}, or {@link
+ * #executeAsyncQuery()}.
+ *
+ * <p>Setter names are the parameter names without the leading colon. For example,
+ * {@code setInt("account_id", 42)} binds {@code :account_id}. Any non-empty name is accepted,
+ * including names used as quoted parameters such as {@code :"order total"}; use {@code "order
+ * total"} in the setter. The same binding supplies every occurrence of a name in the SQL.
+ *
+ * <p>Setting an existing name again replaces its type and value. Binding order is not significant.
+ * {@link #clearParameters()} removes all bindings; executing with no bindings is allowed. SQL
+ * {@code NULL} values follow {@link
+ * DataCloudPreparedStatement}: {@link #setObject(String, Object, int)} with a null value binds an
+ * untyped null, while type-specific setters bind a null of their corresponding type.
+ *
+ * <p>This class exposes only the named setters supported by the driver. It is not a {@link
+ * java.sql.PreparedStatement}, and {@link java.sql.DatabaseMetaData#supportsNamedParameters()}
+ * remains false because that JDBC capability specifically describes named {@link
+ * java.sql.CallableStatement} parameters. Like JDBC statements generally, instances are not
+ * thread-safe.
+ */
+public final class DataCloudNamedPreparedStatement extends DataCloudPreparedStatementBase<String> {
+    private static final String PARAMETER_NAME_ERROR = "Parameter name must not be null or empty";
+
+    final Map<String, ParameterBinding> parameters = new HashMap<>();
+    private final ProvidedParameters providedParameters =
+            new ProvidedParameters(QueryParam.ParameterStyle.NAMED, parameters.entrySet());
+
+    DataCloudNamedPreparedStatement(DataCloudConnection connection, String sql) {
+        super(connection, sql);
+    }
+
+    @Override
+    protected void bindParameter(String parameterName, HyperType type, Object value) throws SQLException {
+        if (parameterName == null || parameterName.isEmpty()) {
+            throw new SQLException(PARAMETER_NAME_ERROR);
+        }
+        parameters.put(parameterName, new ParameterBinding(type, value));
+    }
+
+    @Override
+    protected ProvidedParameters getProvidedParameters() {
+        return providedParameters;
+    }
+
+    @Override
+    public void clearParameters() {
+        parameters.clear();
+    }
+
+    public void setNull(String parameterName, int sqlType) throws SQLException {
+        setNullParameter(parameterName, sqlType);
+    }
+
+    public void setBoolean(String parameterName, boolean value) throws SQLException {
+        setBooleanParameter(parameterName, value);
+    }
+
+    public void setByte(String parameterName, byte value) throws SQLException {
+        setByteParameter(parameterName, value);
+    }
+
+    public void setShort(String parameterName, short value) throws SQLException {
+        setShortParameter(parameterName, value);
+    }
+
+    public void setInt(String parameterName, int value) throws SQLException {
+        setIntParameter(parameterName, value);
+    }
+
+    public void setLong(String parameterName, long value) throws SQLException {
+        setLongParameter(parameterName, value);
+    }
+
+    public void setFloat(String parameterName, float value) throws SQLException {
+        setFloatParameter(parameterName, value);
+    }
+
+    public void setDouble(String parameterName, double value) throws SQLException {
+        setDoubleParameter(parameterName, value);
+    }
+
+    public void setBigDecimal(String parameterName, BigDecimal value) throws SQLException {
+        setBigDecimalParameter(parameterName, value);
+    }
+
+    public void setString(String parameterName, String value) throws SQLException {
+        setStringParameter(parameterName, value);
+    }
+
+    public void setDate(String parameterName, Date value) throws SQLException {
+        setDateParameter(parameterName, value);
+    }
+
+    public void setTime(String parameterName, Time value) throws SQLException {
+        setTimeParameter(parameterName, value);
+    }
+
+    public void setTimestamp(String parameterName, Timestamp value) throws SQLException {
+        setTimestampParameter(parameterName, value);
+    }
+
+    public void setObject(String parameterName, Object value) throws SQLException {
+        setObjectParameter(parameterName, value);
+    }
+
+    public void setObject(String parameterName, Object value, int targetSqlType) throws SQLException {
+        setObjectParameter(parameterName, value, targetSqlType);
+    }
+
+    public void setDate(String parameterName, Date value, Calendar calendar) throws SQLException {
+        setDateParameter(parameterName, value, calendar);
+    }
+
+    public void setTime(String parameterName, Time value, Calendar calendar) throws SQLException {
+        setTimeParameter(parameterName, value, calendar);
+    }
+
+    public void setTimestamp(String parameterName, Timestamp value, Calendar calendar) throws SQLException {
+        setTimestampParameter(parameterName, value, calendar);
+    }
+}

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatement.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatement.java
@@ -4,18 +4,10 @@
  */
 package com.salesforce.datacloud.jdbc.core;
 
-import static com.salesforce.datacloud.jdbc.protocol.data.ArrowUtils.toArrowByteArray;
-import static com.salesforce.datacloud.jdbc.util.DateTimeUtils.getUTCDateFromDateAndCalendar;
-import static com.salesforce.datacloud.jdbc.util.DateTimeUtils.getUTCTimeFromTimeAndCalendar;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import com.google.protobuf.ByteString;
 import com.salesforce.datacloud.jdbc.protocol.data.HyperType;
 import com.salesforce.datacloud.jdbc.protocol.data.ParameterAccumulator;
-import com.salesforce.datacloud.jdbc.util.QueryTimeout;
+import com.salesforce.datacloud.jdbc.protocol.data.ParameterBinding;
 import com.salesforce.datacloud.jdbc.util.SqlErrorCodes;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -28,48 +20,31 @@ import java.sql.NClob;
 import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
 import java.sql.Ref;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.sql.Types;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.util.AbstractList;
+import java.util.AbstractMap;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import salesforce.cdp.hyperdb.v1.QueryParam;
-import salesforce.cdp.hyperdb.v1.QueryParameterArrow;
 
-@Slf4j
-public class DataCloudPreparedStatement extends DataCloudStatement implements PreparedStatement {
-    private String sql;
+/** JDBC {@link PreparedStatement} implementation for positional {@code ?} parameters. */
+public class DataCloudPreparedStatement extends DataCloudPreparedStatementBase<Integer> implements PreparedStatement {
     // Package-private for tests that need to inspect bound parameters.
     final ParameterAccumulator parameters = new ParameterAccumulator();
-    private final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-    // True if we are currently fetching metadata from the server, this influences the query param generation
-    // to not return any data.
-    private boolean fetchingMetadata = false;
-
-    DataCloudPreparedStatement(DataCloudConnection connection) {
-        super(connection);
-    }
+    private final ProvidedParameters providedParameters = new ProvidedParameters(
+            QueryParam.ParameterStyle.QUESTION_MARK, new PositionalParameterEntries(parameters.getParameters()));
 
     DataCloudPreparedStatement(DataCloudConnection connection, String sql) {
-        super(connection);
-        this.sql = sql;
+        super(connection, sql);
     }
 
-    private <T> void setParameter(int parameterIndex, HyperType type, T value) throws SQLException {
+    @Override
+    protected void bindParameter(Integer parameterIndex, HyperType type, Object value) throws SQLException {
         try {
             parameters.setParameter(parameterIndex, type, value);
         } catch (IllegalArgumentException ex) {
@@ -78,164 +53,8 @@ public class DataCloudPreparedStatement extends DataCloudStatement implements Pr
     }
 
     @Override
-    public ResultSet executeQuery(String sql) throws SQLException {
-        throw new SQLException(
-                "Per the JDBC specification this method cannot be called on a PreparedStatement, use DataCloudPreparedStatement::executeQuery() instead.");
-    }
-
-    @Override
-    public boolean execute(String sql) throws SQLException {
-        throw new SQLException(
-                "Per the JDBC specification this method cannot be called on a PreparedStatement, use DataCloudPreparedStatement::execute() instead.");
-    }
-
-    @Override
-    protected QueryParam.Builder getQueryParamBuilder(
-            String sql, QueryTimeout queryTimeout, QueryParam.TransferMode transferMode) throws SQLException {
-        val builder = super.getQueryParamBuilder(sql, queryTimeout, transferMode);
-
-        final byte[] encodedRow;
-        try {
-            encodedRow = toArrowByteArray(parameters.getParameters(), calendar);
-        } catch (IOException e) {
-            throw new SQLException("Failed to encode parameters on prepared statement", e);
-        } catch (IllegalArgumentException e) {
-            // Thrown when a parameter is bound with a HyperType we cannot currently encode as
-            // Arrow (e.g. INTERVAL, JSON). Surface as a JDBC spec-compliant SQLException.
-            throw new SQLException("Failed to encode parameters on prepared statement: " + e.getMessage(), "HY000", e);
-        }
-
-        if (fetchingMetadata) {
-            // Submit the query as metadata only query, with limit 0 Hyper will skip execution.
-            builder.setQueryRowLimit(0);
-        }
-
-        return builder.setParamStyle(QueryParam.ParameterStyle.QUESTION_MARK)
-                .setArrowParameters(QueryParameterArrow.newBuilder()
-                        .setData(ByteString.copyFrom(encodedRow))
-                        .build());
-    }
-
-    public boolean executeAsyncQuery() throws SQLException {
-        super.executeAsyncQueryInternal(sql);
-        return true;
-    }
-
-    @Override
-    public boolean execute() throws SQLException {
-        resultSet = executeQuery();
-        return true;
-    }
-
-    @Override
-    public ResultSet executeQuery() throws SQLException {
-        resultSet = super.executeQuery(sql);
-        return resultSet;
-    }
-
-    @Override
-    public int executeUpdate() throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
-    }
-
-    @Override
-    public void setNull(int parameterIndex, int sqlType) throws SQLException {
-        setParameter(parameterIndex, hyperTypeForJdbcCode(sqlType), null);
-    }
-
-    private static HyperType hyperTypeForJdbcCode(int sqlType) throws SQLException {
-        try {
-            return com.salesforce.datacloud.jdbc.core.types.HyperTypes.fromJdbcTypeCode(sqlType, true);
-        } catch (IllegalArgumentException ex) {
-            throw new SQLException("Unsupported JDBC type code: " + sqlType, "HYC00", ex);
-        }
-    }
-
-    @Override
-    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
-        setParameter(parameterIndex, HyperType.bool(false), x);
-    }
-
-    @Override
-    public void setByte(int parameterIndex, byte x) throws SQLException {
-        setParameter(parameterIndex, HyperType.int8(false), x);
-    }
-
-    @Override
-    public void setShort(int parameterIndex, short x) throws SQLException {
-        setParameter(parameterIndex, HyperType.int16(false), x);
-    }
-
-    @Override
-    public void setInt(int parameterIndex, int x) throws SQLException {
-        setParameter(parameterIndex, HyperType.int32(false), x);
-    }
-
-    @Override
-    public void setLong(int parameterIndex, long x) throws SQLException {
-        setParameter(parameterIndex, HyperType.int64(false), x);
-    }
-
-    @Override
-    public void setFloat(int parameterIndex, float x) throws SQLException {
-        setParameter(parameterIndex, HyperType.float8(false), x);
-    }
-
-    @Override
-    public void setDouble(int parameterIndex, double x) throws SQLException {
-        setParameter(parameterIndex, HyperType.float8(false), x);
-    }
-
-    @Override
-    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
-        final HyperType type;
-        if (x == null) {
-            // Precision/scale are unknown; let Arrow encoding pick a suitable default.
-            type = HyperType.decimal(0, 0, true);
-        } else {
-            type = HyperType.decimal(x.precision(), x.scale(), true);
-        }
-        setParameter(parameterIndex, type, x);
-    }
-
-    @Override
-    public void setString(int parameterIndex, String x) throws SQLException {
-        setParameter(parameterIndex, HyperType.varcharUnlimited(true), x);
-    }
-
-    @Override
-    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
-    }
-
-    @Override
-    public void setDate(int parameterIndex, Date x) throws SQLException {
-        setParameter(parameterIndex, HyperType.date(true), x);
-    }
-
-    @Override
-    public void setTime(int parameterIndex, Time x) throws SQLException {
-        setParameter(parameterIndex, HyperType.time(true), x);
-    }
-
-    @Override
-    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
-        setParameter(parameterIndex, HyperType.timestamp(true), toWallClockAsUtc(x, null));
-    }
-
-    @Override
-    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
-    }
-
-    @Override
-    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
-    }
-
-    @Override
-    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    protected ProvidedParameters getProvidedParameters() {
+        return providedParameters;
     }
 
     @Override
@@ -244,42 +63,93 @@ public class DataCloudPreparedStatement extends DataCloudStatement implements Pr
     }
 
     @Override
-    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
-        if (x == null) {
-            setNull(parameterIndex, Types.NULL);
-            return;
-        }
-        // TIMESTAMP (naive): apply wall-clock normalization for legacy Timestamp,
-        // or store LocalDateTime digits directly.
-        if (targetSqlType == Types.TIMESTAMP) {
-            if (x instanceof Timestamp) {
-                setParameter(parameterIndex, HyperType.timestamp(true), toWallClockAsUtc((Timestamp) x, null));
-                return;
-            }
-            if (x instanceof LocalDateTime) {
-                LocalDateTime ldt = (LocalDateTime) x;
-                // Encode LDT digits as if they were in UTC — no JVM-TZ shift applied.
-                setParameter(parameterIndex, HyperType.timestamp(true), Timestamp.from(ldt.toInstant(ZoneOffset.UTC)));
-                return;
-            }
-        }
-        setParameter(parameterIndex, hyperTypeForJdbcCode(targetSqlType), x);
+    public void setNull(int parameterIndex, int sqlType) throws SQLException {
+        setNullParameter(parameterIndex, sqlType);
     }
 
     @Override
-    public void setObject(int parameterIndex, Object x) throws SQLException {
-        if (x == null) {
-            setNull(parameterIndex, Types.NULL);
-            return;
-        }
+    public void setBoolean(int parameterIndex, boolean value) throws SQLException {
+        setBooleanParameter(parameterIndex, value);
+    }
 
-        TypeHandler handler = TypeHandlers.typeHandlerMap.get(x.getClass());
-        if (handler != null) {
-            handler.setParameter(this, parameterIndex, x);
-        } else {
-            String message = "Object type not supported for: " + x.getClass().getSimpleName() + " (value: " + x + ")";
-            throw new SQLFeatureNotSupportedException(message);
-        }
+    @Override
+    public void setByte(int parameterIndex, byte value) throws SQLException {
+        setByteParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setShort(int parameterIndex, short value) throws SQLException {
+        setShortParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setInt(int parameterIndex, int value) throws SQLException {
+        setIntParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setLong(int parameterIndex, long value) throws SQLException {
+        setLongParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setFloat(int parameterIndex, float value) throws SQLException {
+        setFloatParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setDouble(int parameterIndex, double value) throws SQLException {
+        setDoubleParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setBigDecimal(int parameterIndex, BigDecimal value) throws SQLException {
+        setBigDecimalParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setString(int parameterIndex, String value) throws SQLException {
+        setStringParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date value) throws SQLException {
+        setDateParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time value) throws SQLException {
+        setTimeParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp value) throws SQLException {
+        setTimestampParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object value) throws SQLException {
+        setObjectParameter(parameterIndex, value);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object value, int targetSqlType) throws SQLException {
+        setObjectParameter(parameterIndex, value, targetSqlType);
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date value, Calendar calendar) throws SQLException {
+        setDateParameter(parameterIndex, value, calendar);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time value, Calendar calendar) throws SQLException {
+        setTimeParameter(parameterIndex, value, calendar);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp value, Calendar calendar) throws SQLException {
+        setTimestampParameter(parameterIndex, value, calendar);
     }
 
     @Override
@@ -288,251 +158,179 @@ public class DataCloudPreparedStatement extends DataCloudStatement implements Pr
     }
 
     @Override
+    public void setBytes(int parameterIndex, byte[] value) throws SQLException {
+        throw unsupported();
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream value, int length) throws SQLException {
+        throw unsupported();
+    }
+
+    @Override
+    public void setUnicodeStream(int parameterIndex, InputStream value, int length) throws SQLException {
+        throw unsupported();
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream value, int length) throws SQLException {
+        throw unsupported();
+    }
+
+    @Override
     public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
-    public void setRef(int parameterIndex, Ref x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setRef(int parameterIndex, Ref value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
-    public void setBlob(int parameterIndex, Blob x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setBlob(int parameterIndex, Blob value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
-    public void setClob(int parameterIndex, Clob x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setClob(int parameterIndex, Clob value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
-    public void setArray(int parameterIndex, Array x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
-    }
-
-    @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
-        if ((resultSet != null) && !resultSet.isClosed()) {
-            return resultSet.getMetaData();
-        }
-        try {
-            fetchingMetadata = true;
-            val result = super.executeQuery(sql);
-            val metadata = result.getMetaData();
-            result.close();
-            return metadata;
-        } finally {
-            fetchingMetadata = false;
-        }
-    }
-
-    @Override
-    public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
-        val utcDate = getUTCDateFromDateAndCalendar(x, cal);
-        setParameter(parameterIndex, HyperType.date(true), utcDate);
-    }
-
-    @Override
-    public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
-        val utcTime = getUTCTimeFromTimeAndCalendar(x, cal);
-        setParameter(parameterIndex, HyperType.time(true), utcTime);
-    }
-
-    @Override
-    public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
-        setParameter(parameterIndex, HyperType.timestamp(true), toWallClockAsUtc(x, cal));
-    }
-
-    /**
-     * Converts a Timestamp to a naive-UTC representation for sending as a naive TIMESTAMP parameter.
-     *
-     * <p>Per JDBC spec, {@code setTimestamp(Calendar)} stores the wall-clock value of the Timestamp
-     * in the Calendar's timezone (or JVM default if null) as the literal. For example, if the
-     * Timestamp represents 14:30 UTC and the Calendar is Asia/Tokyo (UTC+9), the stored literal is
-     * "23:30" (the Tokyo wall-clock at that instant).
-     *
-     * <p>We encode this by extracting the wall-clock in the effective timezone, then re-encoding
-     * it as if that wall-clock were in UTC — so the Arrow epoch value carries the wall-clock digits.
-     * Hyper receives a naive {@code TimeStampMicroVector} and stores the literal directly.
-     */
-    private static Timestamp toWallClockAsUtc(Timestamp ts, Calendar cal) {
-        ZoneId zone = cal != null ? cal.getTimeZone().toZoneId() : ZoneId.systemDefault();
-        LocalDateTime wallClock = LocalDateTime.ofInstant(ts.toInstant(), zone);
-        return Timestamp.from(wallClock.toInstant(ZoneOffset.UTC));
+    public void setArray(int parameterIndex, Array value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
     public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
-    public void setURL(int parameterIndex, URL x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setURL(int parameterIndex, URL value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
     public ParameterMetaData getParameterMetaData() throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
-    public void setRowId(int parameterIndex, RowId x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setRowId(int parameterIndex, RowId value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
     public void setNString(int parameterIndex, String value) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setNClob(int parameterIndex, NClob value) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
-    public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setSQLXML(int parameterIndex, SQLXML value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
-    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setObject(int parameterIndex, Object value, int targetSqlType, int scaleOrLength) throws SQLException {
+        throw unsupported();
     }
 
     @Override
-    public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setAsciiStream(int parameterIndex, InputStream value, long length) throws SQLException {
+        throw unsupported();
     }
 
     @Override
-    public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setBinaryStream(int parameterIndex, InputStream value, long length) throws SQLException {
+        throw unsupported();
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
-    public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setAsciiStream(int parameterIndex, InputStream value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
-    public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    public void setBinaryStream(int parameterIndex, InputStream value) throws SQLException {
+        throw unsupported();
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
-        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+        throw unsupported();
     }
 
-    @Override
-    public <T> T unwrap(Class<T> iFace) throws SQLException {
-        if (iFace.isInstance(this)) {
-            return iFace.cast(this);
+    private static SQLException unsupported() {
+        return new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    }
+
+    private static final class PositionalParameterEntries extends AbstractList<Map.Entry<String, ParameterBinding>> {
+        private final List<ParameterBinding> bindings;
+
+        private PositionalParameterEntries(List<ParameterBinding> bindings) {
+            this.bindings = bindings;
         }
-        throw new SQLException("Cannot unwrap to " + iFace.getName());
-    }
 
-    @Override
-    public boolean isWrapperFor(Class<?> iFace) {
-        return iFace.isInstance(this);
-    }
-}
+        @Override
+        public Map.Entry<String, ParameterBinding> get(int index) {
+            return new AbstractMap.SimpleImmutableEntry<>(String.valueOf(index + 1), bindings.get(index));
+        }
 
-@FunctionalInterface
-interface TypeHandler {
-    void setParameter(PreparedStatement ps, int parameterIndex, Object value) throws SQLException;
-}
-
-final class TypeHandlers {
-    public static final TypeHandler STRING_HANDLER = (ps, idx, value) -> ps.setString(idx, (String) value);
-    public static final TypeHandler BIGDECIMAL_HANDLER = (ps, idx, value) -> ps.setBigDecimal(idx, (BigDecimal) value);
-    public static final TypeHandler SHORT_HANDLER = (ps, idx, value) -> ps.setShort(idx, (Short) value);
-    public static final TypeHandler INTEGER_HANDLER = (ps, idx, value) -> ps.setInt(idx, (Integer) value);
-    public static final TypeHandler LONG_HANDLER = (ps, idx, value) -> ps.setLong(idx, (Long) value);
-    public static final TypeHandler FLOAT_HANDLER = (ps, idx, value) -> ps.setFloat(idx, (Float) value);
-    public static final TypeHandler DOUBLE_HANDLER = (ps, idx, value) -> ps.setDouble(idx, (Double) value);
-    public static final TypeHandler DATE_HANDLER = (ps, idx, value) -> ps.setDate(idx, (Date) value);
-    public static final TypeHandler TIME_HANDLER = (ps, idx, value) -> ps.setTime(idx, (Time) value);
-    public static final TypeHandler TIMESTAMP_HANDLER = (ps, idx, value) -> ps.setTimestamp(idx, (Timestamp) value);
-    public static final TypeHandler BOOLEAN_HANDLER = (ps, idx, value) -> ps.setBoolean(idx, (Boolean) value);
-
-    // JDBC 4.2 java.time handlers — mapped per JDBC spec Table B-4:
-    //   LocalDateTime    → TIMESTAMP               (wall-clock digits, no TZ shift)
-    //   OffsetDateTime   → TIMESTAMP_WITH_TIMEZONE (UTC epoch; recommended write path for TIMESTAMPTZ)
-    //   ZonedDateTime    → TIMESTAMP_WITH_TIMEZONE (UTC epoch)
-    public static final TypeHandler LOCAL_DATE_TIME_HANDLER =
-            (ps, idx, value) -> ps.setObject(idx, value, Types.TIMESTAMP);
-    public static final TypeHandler OFFSET_DATE_TIME_HANDLER = (ps, idx, value) ->
-            ps.setObject(idx, Timestamp.from(((OffsetDateTime) value).toInstant()), Types.TIMESTAMP_WITH_TIMEZONE);
-    public static final TypeHandler ZONED_DATE_TIME_HANDLER = (ps, idx, value) ->
-            ps.setObject(idx, Timestamp.from(((ZonedDateTime) value).toInstant()), Types.TIMESTAMP_WITH_TIMEZONE);
-
-    static final Map<Class<?>, TypeHandler> typeHandlerMap = ImmutableMap.ofEntries(
-            Maps.immutableEntry(String.class, STRING_HANDLER),
-            Maps.immutableEntry(BigDecimal.class, BIGDECIMAL_HANDLER),
-            Maps.immutableEntry(Short.class, SHORT_HANDLER),
-            Maps.immutableEntry(Integer.class, INTEGER_HANDLER),
-            Maps.immutableEntry(Long.class, LONG_HANDLER),
-            Maps.immutableEntry(Float.class, FLOAT_HANDLER),
-            Maps.immutableEntry(Double.class, DOUBLE_HANDLER),
-            Maps.immutableEntry(Date.class, DATE_HANDLER),
-            Maps.immutableEntry(Time.class, TIME_HANDLER),
-            Maps.immutableEntry(Timestamp.class, TIMESTAMP_HANDLER),
-            Maps.immutableEntry(Boolean.class, BOOLEAN_HANDLER),
-            Maps.immutableEntry(LocalDateTime.class, LOCAL_DATE_TIME_HANDLER),
-            Maps.immutableEntry(OffsetDateTime.class, OFFSET_DATE_TIME_HANDLER),
-            Maps.immutableEntry(ZonedDateTime.class, ZONED_DATE_TIME_HANDLER));
-
-    private TypeHandlers() {
-        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+        @Override
+        public int size() {
+            return bindings.size();
+        }
     }
 }

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatementBase.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatementBase.java
@@ -1,0 +1,333 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import static com.salesforce.datacloud.jdbc.protocol.data.ArrowUtils.toArrowByteArray;
+import static com.salesforce.datacloud.jdbc.util.DateTimeUtils.getUTCDateFromDateAndCalendar;
+import static com.salesforce.datacloud.jdbc.util.DateTimeUtils.getUTCTimeFromTimeAndCalendar;
+
+import com.google.protobuf.ByteString;
+import com.salesforce.datacloud.jdbc.protocol.data.HyperType;
+import com.salesforce.datacloud.jdbc.protocol.data.HyperTypeKind;
+import com.salesforce.datacloud.jdbc.protocol.data.ParameterBinding;
+import com.salesforce.datacloud.jdbc.util.QueryTimeout;
+import com.salesforce.datacloud.jdbc.util.SqlErrorCodes;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Map;
+import java.util.TimeZone;
+import lombok.val;
+import salesforce.cdp.hyperdb.v1.QueryParam;
+import salesforce.cdp.hyperdb.v1.QueryParameterArrow;
+
+/** Shared prepared-statement execution and value conversion for positional and named parameters. */
+abstract class DataCloudPreparedStatementBase<P> extends DataCloudStatement {
+    private final String sql;
+    private final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    private boolean fetchingMetadata;
+
+    DataCloudPreparedStatementBase(DataCloudConnection connection, String sql) {
+        super(connection);
+        this.sql = sql;
+    }
+
+    /** Stores one typed parameter using the parameter representation of the concrete statement. */
+    protected abstract void bindParameter(P parameter, HyperType type, Object value) throws SQLException;
+
+    protected abstract ProvidedParameters getProvidedParameters();
+
+    public abstract void clearParameters();
+
+    @Override
+    public ResultSet executeQuery(String sql) throws SQLException {
+        throw new SQLException("Per the JDBC specification this method cannot be called on a PreparedStatement, use "
+                + getClass().getSimpleName()
+                + "::executeQuery() instead.");
+    }
+
+    @Override
+    public boolean execute(String sql) throws SQLException {
+        throw new SQLException("Per the JDBC specification this method cannot be called on a PreparedStatement, use "
+                + getClass().getSimpleName()
+                + "::execute() instead.");
+    }
+
+    @Override
+    public DataCloudStatement executeAsyncQuery(String sql) throws SQLException {
+        throw new SQLException("This method cannot be called on a prepared statement, use "
+                + getClass().getSimpleName()
+                + "::executeAsyncQuery() instead.");
+    }
+
+    @Override
+    protected QueryParam.Builder getQueryParamBuilder(
+            String sql, QueryTimeout queryTimeout, QueryParam.TransferMode transferMode) throws SQLException {
+        val builder = super.getQueryParamBuilder(sql, queryTimeout, transferMode);
+
+        final byte[] encodedRow;
+        ProvidedParameters providedParameters = getProvidedParameters();
+        try {
+            encodedRow = toArrowByteArray(providedParameters.getEntries(), calendar);
+        } catch (IOException e) {
+            throw new SQLException("Failed to encode parameters on prepared statement", e);
+        } catch (RuntimeException e) {
+            throw new SQLException("Failed to encode parameters on prepared statement: " + e.getMessage(), "HY000", e);
+        }
+
+        if (fetchingMetadata) {
+            builder.setQueryRowLimit(0);
+        }
+
+        return builder.setParamStyle(providedParameters.getStyle())
+                .setArrowParameters(QueryParameterArrow.newBuilder()
+                        .setData(ByteString.copyFrom(encodedRow))
+                        .build());
+    }
+
+    public boolean executeAsyncQuery() throws SQLException {
+        super.executeAsyncQueryInternal(sql);
+        return true;
+    }
+
+    public boolean execute() throws SQLException {
+        resultSet = executeQuery();
+        return true;
+    }
+
+    public ResultSet executeQuery() throws SQLException {
+        resultSet = super.executeQuery(sql);
+        return resultSet;
+    }
+
+    public int executeUpdate() throws SQLException {
+        throw new SQLException(NOT_SUPPORTED_IN_DATACLOUD_QUERY, SqlErrorCodes.FEATURE_NOT_SUPPORTED);
+    }
+
+    public ResultSetMetaData getMetaData() throws SQLException {
+        if ((resultSet != null) && !resultSet.isClosed()) {
+            return resultSet.getMetaData();
+        }
+        try {
+            fetchingMetadata = true;
+            val result = super.executeQuery(sql);
+            val metadata = result.getMetaData();
+            result.close();
+            return metadata;
+        } finally {
+            fetchingMetadata = false;
+        }
+    }
+
+    protected final void setNullParameter(P parameter, int sqlType) throws SQLException {
+        HyperType type = hyperTypeForJdbcCode(sqlType);
+        if (!isBindableParameterType(type.getKind())) {
+            throw new SQLFeatureNotSupportedException(
+                    "Binding null parameters of JDBC type " + sqlType + " is not supported", "HYC00");
+        }
+        setParameter(parameter, type, null);
+    }
+
+    protected final void setBooleanParameter(P parameter, boolean value) throws SQLException {
+        setParameter(parameter, HyperType.bool(false), value);
+    }
+
+    protected final void setByteParameter(P parameter, byte value) throws SQLException {
+        setParameter(parameter, HyperType.int8(false), value);
+    }
+
+    protected final void setShortParameter(P parameter, short value) throws SQLException {
+        setParameter(parameter, HyperType.int16(false), value);
+    }
+
+    protected final void setIntParameter(P parameter, int value) throws SQLException {
+        setParameter(parameter, HyperType.int32(false), value);
+    }
+
+    protected final void setLongParameter(P parameter, long value) throws SQLException {
+        setParameter(parameter, HyperType.int64(false), value);
+    }
+
+    protected final void setFloatParameter(P parameter, float value) throws SQLException {
+        setParameter(parameter, HyperType.float4(false), value);
+    }
+
+    protected final void setDoubleParameter(P parameter, double value) throws SQLException {
+        setParameter(parameter, HyperType.float8(false), value);
+    }
+
+    protected final void setBigDecimalParameter(P parameter, BigDecimal value) throws SQLException {
+        HyperType type = value == null
+                ? HyperType.decimal(0, 0, true)
+                : HyperType.decimal(value.precision(), value.scale(), true);
+        setParameter(parameter, type, value);
+    }
+
+    protected final void setStringParameter(P parameter, String value) throws SQLException {
+        setParameter(parameter, HyperType.varcharUnlimited(true), value);
+    }
+
+    protected final void setDateParameter(P parameter, Date value) throws SQLException {
+        setParameter(parameter, HyperType.date(true), value);
+    }
+
+    protected final void setTimeParameter(P parameter, Time value) throws SQLException {
+        setParameter(parameter, HyperType.time(true), value);
+    }
+
+    protected final void setTimestampParameter(P parameter, Timestamp value) throws SQLException {
+        setParameter(parameter, HyperType.timestamp(true), value == null ? null : toWallClockAsUtc(value, null));
+    }
+
+    protected final void setObjectParameter(P parameter, Object value, int targetSqlType) throws SQLException {
+        if (value == null) {
+            setNullParameter(parameter, Types.NULL);
+            return;
+        }
+        if (targetSqlType == Types.TIMESTAMP) {
+            if (value instanceof Timestamp) {
+                setParameter(parameter, HyperType.timestamp(true), toWallClockAsUtc((Timestamp) value, null));
+                return;
+            }
+            if (value instanceof LocalDateTime) {
+                LocalDateTime dateTime = (LocalDateTime) value;
+                setParameter(parameter, HyperType.timestamp(true), Timestamp.from(dateTime.toInstant(ZoneOffset.UTC)));
+                return;
+            }
+        }
+        setParameter(parameter, hyperTypeForJdbcCode(targetSqlType), value);
+    }
+
+    protected final void setObjectParameter(P parameter, Object value) throws SQLException {
+        if (value == null) {
+            setNullParameter(parameter, Types.NULL);
+            return;
+        }
+
+        Class<?> valueClass = value.getClass();
+        if (valueClass == String.class) {
+            setStringParameter(parameter, (String) value);
+        } else if (valueClass == BigDecimal.class) {
+            setBigDecimalParameter(parameter, (BigDecimal) value);
+        } else if (valueClass == Short.class) {
+            setShortParameter(parameter, (Short) value);
+        } else if (valueClass == Integer.class) {
+            setIntParameter(parameter, (Integer) value);
+        } else if (valueClass == Long.class) {
+            setLongParameter(parameter, (Long) value);
+        } else if (valueClass == Float.class) {
+            setFloatParameter(parameter, (Float) value);
+        } else if (valueClass == Double.class) {
+            setDoubleParameter(parameter, (Double) value);
+        } else if (valueClass == Date.class) {
+            setDateParameter(parameter, (Date) value);
+        } else if (valueClass == Time.class) {
+            setTimeParameter(parameter, (Time) value);
+        } else if (valueClass == Timestamp.class) {
+            setTimestampParameter(parameter, (Timestamp) value);
+        } else if (valueClass == Boolean.class) {
+            setBooleanParameter(parameter, (Boolean) value);
+        } else if (valueClass == LocalDateTime.class) {
+            setObjectParameter(parameter, value, Types.TIMESTAMP);
+        } else if (valueClass == OffsetDateTime.class) {
+            setObjectParameter(
+                    parameter, Timestamp.from(((OffsetDateTime) value).toInstant()), Types.TIMESTAMP_WITH_TIMEZONE);
+        } else if (valueClass == ZonedDateTime.class) {
+            setObjectParameter(
+                    parameter, Timestamp.from(((ZonedDateTime) value).toInstant()), Types.TIMESTAMP_WITH_TIMEZONE);
+        } else {
+            String message = "Object type not supported for: " + valueClass.getSimpleName() + " (value: " + value + ")";
+            throw new SQLFeatureNotSupportedException(message);
+        }
+    }
+
+    protected final void setDateParameter(P parameter, Date value, Calendar calendar) throws SQLException {
+        setParameter(
+                parameter, HyperType.date(true), value == null ? null : getUTCDateFromDateAndCalendar(value, calendar));
+    }
+
+    protected final void setTimeParameter(P parameter, Time value, Calendar calendar) throws SQLException {
+        setParameter(
+                parameter, HyperType.time(true), value == null ? null : getUTCTimeFromTimeAndCalendar(value, calendar));
+    }
+
+    protected final void setTimestampParameter(P parameter, Timestamp value, Calendar calendar) throws SQLException {
+        setParameter(parameter, HyperType.timestamp(true), value == null ? null : toWallClockAsUtc(value, calendar));
+    }
+
+    private void setParameter(P parameter, HyperType type, Object value) throws SQLException {
+        bindParameter(parameter, type, value);
+    }
+
+    private static HyperType hyperTypeForJdbcCode(int sqlType) throws SQLException {
+        try {
+            return com.salesforce.datacloud.jdbc.core.types.HyperTypes.fromJdbcTypeCode(sqlType, true);
+        } catch (IllegalArgumentException ex) {
+            throw new SQLException("Unsupported JDBC type code: " + sqlType, "HYC00", ex);
+        }
+    }
+
+    private static boolean isBindableParameterType(HyperTypeKind kind) {
+        switch (kind) {
+            case BOOL:
+            case INT8:
+            case INT16:
+            case INT32:
+            case INT64:
+            case FLOAT4:
+            case FLOAT8:
+            case DECIMAL:
+            case CHAR:
+            case VARCHAR:
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case TIMESTAMP_TZ:
+            case NULL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static Timestamp toWallClockAsUtc(Timestamp timestamp, Calendar calendar) {
+        // Arrow carries the wall-clock digits as a UTC instant for Hyper's naive TIMESTAMP type.
+        ZoneId zone = calendar != null ? calendar.getTimeZone().toZoneId() : ZoneId.systemDefault();
+        LocalDateTime wallClock = LocalDateTime.ofInstant(timestamp.toInstant(), zone);
+        return Timestamp.from(wallClock.toInstant(ZoneOffset.UTC));
+    }
+
+    static final class ProvidedParameters {
+        private final QueryParam.ParameterStyle style;
+        private final Iterable<? extends Map.Entry<String, ParameterBinding>> entries;
+
+        ProvidedParameters(
+                QueryParam.ParameterStyle style, Iterable<? extends Map.Entry<String, ParameterBinding>> entries) {
+            this.style = style;
+            this.entries = entries;
+        }
+
+        QueryParam.ParameterStyle getStyle() {
+            return style;
+        }
+
+        Iterable<? extends Map.Entry<String, ParameterBinding>> getEntries() {
+            return entries;
+        }
+    }
+}

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/data/ArrowUtils.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/data/ArrowUtils.java
@@ -7,10 +7,13 @@ package com.salesforce.datacloud.jdbc.protocol.data;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -22,6 +25,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 
 @Slf4j
 public final class ArrowUtils {
+    private static final int UNSPECIFIED_DECIMAL_PRECISION = 38;
 
     private ArrowUtils() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
@@ -39,49 +43,57 @@ public final class ArrowUtils {
      * @param parameterBindings a list of ParameterBinding objects
      * @return a Schema object corresponding to the provided parameters
      */
-    public static Schema createSchemaFromParameters(List<ParameterBinding> parameterBindings) {
-        if (parameterBindings == null) {
-            throw new IllegalArgumentException("ParameterBindings list cannot be null");
-        }
+    public static Schema createSchemaFromParameters(@NonNull List<ParameterBinding> parameterBindings) {
         List<Field> fields = IntStream.range(0, parameterBindings.size())
-                .mapToObj(i -> createField(parameterBindings.get(i), i + 1))
+                .mapToObj(i -> createField(String.valueOf(i + 1), parameterBindings.get(i)))
                 .collect(Collectors.toList());
 
         return new Schema(fields);
     }
 
-    private static Field createField(ParameterBinding parameterBinding, int index) {
-        String name = String.valueOf(index);
+    private static Field createField(String name, ParameterBinding parameterBinding) {
         if (parameterBinding == null) {
             // Default type for null values, using VARCHAR for simplicity.
             return new Field(name, FieldType.nullable(new ArrowType.Utf8()), null);
         }
-        HyperType type = materializeDecimal(parameterBinding);
+        HyperType type = materializeParameterType(parameterBinding);
         return HyperTypeToArrow.toField(name, type);
     }
 
     /**
-     * If the parameter was bound with an under-specified DECIMAL type (e.g. via
-     * {@link java.sql.PreparedStatement#setNull(int, int)} where we do not yet know precision
-     * and scale), derive those from the actual {@link BigDecimal} value so Arrow can build a
-     * valid {@link ArrowType.Decimal}.
+     * Materializes parameter types that Arrow or Hyper cannot accept as bound. Under-specified
+     * decimals derive precision from their value or use Hyper's maximum precision for null. Arrow
+     * null fields are unsupported by Hyper, so an untyped null is represented as nullable VARCHAR.
      */
-    private static HyperType materializeDecimal(ParameterBinding parameterBinding) {
+    private static HyperType materializeParameterType(ParameterBinding parameterBinding) {
         HyperType type = parameterBinding.getType();
-        if (type.getKind() == HyperTypeKind.DECIMAL
-                && type.getPrecision() <= 0
-                && parameterBinding.getValue() instanceof BigDecimal) {
-            BigDecimal bd = (BigDecimal) parameterBinding.getValue();
-            return HyperType.decimal(bd.precision(), bd.scale(), type.isNullable());
+        if (type.getKind() == HyperTypeKind.NULL && parameterBinding.getValue() == null) {
+            return HyperType.varcharUnlimited(true);
+        }
+        if (type.getKind() == HyperTypeKind.DECIMAL && type.getPrecision() <= 0) {
+            if (parameterBinding.getValue() instanceof BigDecimal) {
+                BigDecimal bd = (BigDecimal) parameterBinding.getValue();
+                return HyperType.decimal(bd.precision(), bd.scale(), type.isNullable());
+            }
+            if (parameterBinding.getValue() == null) {
+                return HyperType.decimal(UNSPECIFIED_DECIMAL_PRECISION, 0, type.isNullable());
+            }
         }
         return type;
     }
 
-    public static byte[] toArrowByteArray(List<ParameterBinding> parameters, Calendar calendar) throws IOException {
-        Schema schema = ArrowUtils.createSchemaFromParameters(parameters);
+    public static byte[] toArrowByteArray(
+            @NonNull Iterable<? extends Map.Entry<String, ParameterBinding>> parameterEntries, Calendar calendar)
+            throws IOException {
+        List<Field> fields = new ArrayList<>();
+        List<ParameterBinding> parameters = new ArrayList<>();
+        for (Map.Entry<String, ParameterBinding> entry : parameterEntries) {
+            fields.add(createField(entry.getKey(), entry.getValue()));
+            parameters.add(entry.getValue());
+        }
 
         try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-                VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+                VectorSchemaRoot root = VectorSchemaRoot.create(new Schema(fields), allocator)) {
             root.allocateNew();
             VectorPopulator.populateVectors(root, parameters, calendar);
 

--- a/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/data/VectorPopulator.java
+++ b/jdbc-core/src/main/java/com/salesforce/datacloud/jdbc/protocol/data/VectorPopulator.java
@@ -64,6 +64,10 @@ public final class VectorPopulator {
                 continue;
             }
             HyperTypeKind kind = binding.getType().getKind();
+            if (kind == HyperTypeKind.NULL && binding.getValue() == null) {
+                // NullVector needs no setter; every row is null by definition.
+                continue;
+            }
             ValueVector vector =
                     root.getVector(root.getSchema().getFields().get(i).getName());
             setCell(vector, kind, 0, binding.getValue(), calendar);

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudConnectionTest.java
@@ -35,6 +35,14 @@ class DataCloudConnectionTest extends InterceptedHyperTestBase {
     }
 
     @Test
+    void testPrepareNamedStatement() {
+        try (val connection = getInterceptedClientConnection()) {
+            val statement = connection.prepareNamedStatement("SELECT :value");
+            assertThat(statement).isInstanceOf(DataCloudNamedPreparedStatement.class);
+        }
+    }
+
+    @Test
     void testClose() {
         try (val connection = getInterceptedClientConnection()) {
             assertThat(connection.isClosed()).isFalse();

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudNamedPreparedStatementTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudNamedPreparedStatementTest.java
@@ -1,0 +1,193 @@
+/**
+ * This file is part of https://github.com/forcedotcom/datacloud-jdbc which is released under the
+ * Apache 2.0 license. See https://github.com/forcedotcom/datacloud-jdbc/blob/main/LICENSE.txt
+ */
+package com.salesforce.datacloud.jdbc.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.salesforce.datacloud.jdbc.protocol.data.HyperType;
+import com.salesforce.datacloud.jdbc.protocol.data.ParameterBinding;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DataCloudNamedPreparedStatementTest extends InterceptedHyperTestBase {
+    private DataCloudNamedPreparedStatement preparedStatement;
+
+    @BeforeEach
+    void setUp() {
+        preparedStatement = getInterceptedClientConnection()
+                .prepareNamedStatement("SELECT :left_value + :right_value AS total, :left_value AS left_value");
+    }
+
+    @Test
+    void bindsParametersByName() throws SQLException {
+        preparedStatement.setInt("right_value", 2);
+        preparedStatement.setInt("left_value", 40);
+        preparedStatement.setInt("right_value", 3);
+
+        assertThat(preparedStatement.parameters)
+                .hasSize(2)
+                .containsEntry("right_value", new ParameterBinding(HyperType.int32(false), 3))
+                .containsEntry("left_value", new ParameterBinding(HyperType.int32(false), 40));
+    }
+
+    @Test
+    void acceptsExactQuotedParameterName() throws SQLException {
+        preparedStatement.setString("order total", "value");
+
+        assertThat(preparedStatement.parameters)
+                .containsEntry("order total", new ParameterBinding(HyperType.varcharUnlimited(true), "value"));
+    }
+
+    @Test
+    void rejectsEmptyParameterNames() {
+        assertThatThrownBy(() -> preparedStatement.setString("", "value"))
+                .isInstanceOf(SQLException.class)
+                .hasMessage("Parameter name must not be null or empty");
+        assertThatThrownBy(() -> preparedStatement.setString(null, "value"))
+                .isInstanceOf(SQLException.class)
+                .hasMessage("Parameter name must not be null or empty");
+    }
+
+    @Test
+    void clearParametersRemovesNamedBindings() throws SQLException {
+        preparedStatement.setInt("left_value", 40);
+
+        preparedStatement.clearParameters();
+
+        assertThat(preparedStatement.parameters).isEmpty();
+    }
+
+    @Test
+    void setObjectUsesSharedTypeMapping() throws SQLException {
+        preparedStatement.setObject("left_value", 40);
+        preparedStatement.setObject("right_value", null, Types.INTEGER);
+
+        assertThat(preparedStatement.parameters)
+                .containsEntry("left_value", new ParameterBinding(HyperType.int32(false), 40))
+                .containsEntry("right_value", new ParameterBinding(HyperType.nullType(), null));
+    }
+
+    @Test
+    void nullTimestampRetainsTimestampType() throws SQLException {
+        preparedStatement.setTimestamp("left_value", null);
+        preparedStatement.setTimestamp("right_value", null, java.util.Calendar.getInstance());
+
+        assertThat(preparedStatement.parameters)
+                .containsEntry("left_value", new ParameterBinding(HyperType.timestamp(true), null))
+                .containsEntry("right_value", new ParameterBinding(HyperType.timestamp(true), null));
+    }
+
+    @Test
+    void nullCalendarDateAndTimeRetainTheirTypes() throws SQLException {
+        preparedStatement.setDate("left_value", null, java.util.Calendar.getInstance());
+        preparedStatement.setTime("right_value", null, java.util.Calendar.getInstance());
+
+        assertThat(preparedStatement.parameters)
+                .containsEntry("left_value", new ParameterBinding(HyperType.date(true), null))
+                .containsEntry("right_value", new ParameterBinding(HyperType.time(true), null));
+    }
+
+    @Test
+    void rejectsStatementSqlOverrides() {
+        assertThatThrownBy(() -> preparedStatement.executeQuery("SELECT 1"))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("use DataCloudNamedPreparedStatement::executeQuery() instead");
+        assertThatThrownBy(() -> preparedStatement.execute("SELECT 1"))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("use DataCloudNamedPreparedStatement::execute() instead");
+        assertThatThrownBy(() -> preparedStatement.executeAsyncQuery("SELECT 1"))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("use DataCloudNamedPreparedStatement::executeAsyncQuery() instead");
+    }
+
+    @Test
+    void executesNamedParametersAgainstHyper() throws SQLException {
+        preparedStatement.setInt("left_value", 40);
+        preparedStatement.setInt("right_value", 2);
+
+        try (java.sql.ResultSet resultSet = preparedStatement.executeQuery()) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getInt("total")).isEqualTo(42);
+            assertThat(resultSet.getInt("left_value")).isEqualTo(40);
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    @Test
+    void executesFloatParameterAgainstHyper() throws SQLException {
+        try (DataCloudNamedPreparedStatement statement =
+                getInterceptedClientConnection().prepareNamedStatement("SELECT :float_value AS float_value")) {
+            statement.setFloat("float_value", 1.5f);
+
+            try (java.sql.ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getFloat("float_value")).isEqualTo(1.5f);
+            }
+        }
+    }
+
+    @Test
+    void executesQuotedParameterNameContainingSpacesAgainstHyper() throws SQLException {
+        try (DataCloudNamedPreparedStatement statement =
+                getInterceptedClientConnection().prepareNamedStatement("SELECT :\"order total\" AS total")) {
+            statement.setInt("order total", 42);
+
+            try (java.sql.ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getInt("total")).isEqualTo(42);
+                assertThat(resultSet.next()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    void executesDecimalNullsAgainstHyper() throws SQLException {
+        try (DataCloudNamedPreparedStatement statement = getInterceptedClientConnection()
+                .prepareNamedStatement("SELECT :setter_null IS NULL AS setter_null, :typed_null IS NULL AS typed_null, "
+                        + ":untyped_null IS NULL AS untyped_null")) {
+            statement.setBigDecimal("setter_null", null);
+            statement.setNull("typed_null", Types.DECIMAL);
+            statement.setObject("untyped_null", null);
+
+            try (java.sql.ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getBoolean("setter_null")).isTrue();
+                assertThat(resultSet.getBoolean("typed_null")).isTrue();
+                assertThat(resultSet.getBoolean("untyped_null")).isTrue();
+            }
+        }
+    }
+
+    @Test
+    void rejectsNullTypesWithoutParameterEncodingSupport() {
+        int[] unsupportedTypes = {
+            Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY, Types.TIME_WITH_TIMEZONE, Types.ARRAY
+        };
+
+        for (int unsupportedType : unsupportedTypes) {
+            assertThatThrownBy(() -> preparedStatement.setNull("value", unsupportedType))
+                    .isInstanceOf(SQLFeatureNotSupportedException.class)
+                    .hasFieldOrPropertyWithValue("SQLState", "HYC00")
+                    .hasMessageContaining("JDBC type " + unsupportedType);
+        }
+    }
+
+    @Test
+    void reportsParameterEncodingFailuresAsSqlExceptions() throws SQLException {
+        try (DataCloudNamedPreparedStatement statement =
+                getInterceptedClientConnection().prepareNamedStatement("SELECT :value")) {
+            statement.setObject("value", "not an integer", Types.INTEGER);
+
+            assertThatThrownBy(statement::executeQuery)
+                    .isInstanceOf(SQLException.class)
+                    .hasFieldOrPropertyWithValue("SQLState", "HY000")
+                    .hasMessageContaining("Failed to encode parameters on prepared statement");
+        }
+    }
+}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatementTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/core/DataCloudPreparedStatementTest.java
@@ -10,10 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import com.salesforce.datacloud.jdbc.protocol.data.HyperType;
 import com.salesforce.datacloud.jdbc.protocol.data.ParameterBinding;
@@ -106,6 +104,28 @@ public class DataCloudPreparedStatementTest extends InterceptedHyperTestBase {
     }
 
     @Test
+    void testNullTimestampRetainsTimestampType() throws SQLException {
+        preparedStatement.setTimestamp(1, null);
+        preparedStatement.setTimestamp(2, null, calendar);
+
+        assertThat(preparedStatement.parameters.getParameters())
+                .containsExactly(
+                        new ParameterBinding(HyperType.timestamp(true), null),
+                        new ParameterBinding(HyperType.timestamp(true), null));
+    }
+
+    @Test
+    void testNullCalendarDateAndTimeRetainTheirTypes() throws SQLException {
+        preparedStatement.setDate(1, null, calendar);
+        preparedStatement.setTime(2, null, calendar);
+
+        assertThat(preparedStatement.parameters.getParameters())
+                .containsExactly(
+                        new ParameterBinding(HyperType.date(true), null),
+                        new ParameterBinding(HyperType.time(true), null));
+    }
+
+    @Test
     @SneakyThrows
     void testAllSetMethods() {
         preparedStatement.setString(1, "TEST");
@@ -134,7 +154,7 @@ public class DataCloudPreparedStatementTest extends InterceptedHyperTestBase {
 
         preparedStatement.setFloat(7, 5.0f);
         assertThat(preparedStatement.parameters.getParameters().get(6))
-                .isEqualTo(new ParameterBinding(HyperType.float8(false), 5.0f));
+                .isEqualTo(new ParameterBinding(HyperType.float4(false), 5.0f));
 
         preparedStatement.setDouble(8, 6.0);
         assertThat(preparedStatement.parameters.getParameters().get(7))
@@ -314,60 +334,6 @@ public class DataCloudPreparedStatementTest extends InterceptedHyperTestBase {
 
         preparedStatement.setQueryTimeout(-1);
         assertThat(preparedStatement.getQueryTimeout()).isEqualTo(0);
-    }
-
-    @Test
-    void testTypeHandlerMapInitialization() {
-        assertEquals(TypeHandlers.STRING_HANDLER, TypeHandlers.typeHandlerMap.get(String.class));
-        assertEquals(TypeHandlers.BIGDECIMAL_HANDLER, TypeHandlers.typeHandlerMap.get(BigDecimal.class));
-        assertEquals(TypeHandlers.SHORT_HANDLER, TypeHandlers.typeHandlerMap.get(Short.class));
-        assertEquals(TypeHandlers.INTEGER_HANDLER, TypeHandlers.typeHandlerMap.get(Integer.class));
-        assertEquals(TypeHandlers.LONG_HANDLER, TypeHandlers.typeHandlerMap.get(Long.class));
-        assertEquals(TypeHandlers.FLOAT_HANDLER, TypeHandlers.typeHandlerMap.get(Float.class));
-        assertEquals(TypeHandlers.DOUBLE_HANDLER, TypeHandlers.typeHandlerMap.get(Double.class));
-        assertEquals(TypeHandlers.DATE_HANDLER, TypeHandlers.typeHandlerMap.get(Date.class));
-        assertEquals(TypeHandlers.TIME_HANDLER, TypeHandlers.typeHandlerMap.get(Time.class));
-        assertEquals(TypeHandlers.TIMESTAMP_HANDLER, TypeHandlers.typeHandlerMap.get(Timestamp.class));
-        assertEquals(TypeHandlers.BOOLEAN_HANDLER, TypeHandlers.typeHandlerMap.get(Boolean.class));
-    }
-
-    @Test
-    @SneakyThrows
-    void testAllTypeHandlers() {
-        PreparedStatement ps = mock(PreparedStatement.class);
-
-        TypeHandlers.STRING_HANDLER.setParameter(ps, 1, "test");
-        verify(ps).setString(1, "test");
-
-        TypeHandlers.BIGDECIMAL_HANDLER.setParameter(ps, 1, new BigDecimal("123.45"));
-        verify(ps).setBigDecimal(1, new BigDecimal("123.45"));
-
-        TypeHandlers.SHORT_HANDLER.setParameter(ps, 1, (short) 123);
-        verify(ps).setShort(1, (short) 123);
-
-        TypeHandlers.INTEGER_HANDLER.setParameter(ps, 1, 123);
-        verify(ps).setInt(1, 123);
-
-        TypeHandlers.LONG_HANDLER.setParameter(ps, 1, 123L);
-        verify(ps).setLong(1, 123L);
-
-        TypeHandlers.FLOAT_HANDLER.setParameter(ps, 1, 123.45f);
-        verify(ps).setFloat(1, 123.45f);
-
-        TypeHandlers.DOUBLE_HANDLER.setParameter(ps, 1, 123.45);
-        verify(ps).setDouble(1, 123.45);
-
-        TypeHandlers.DATE_HANDLER.setParameter(ps, 1, Date.valueOf("2024-08-15"));
-        verify(ps).setDate(1, Date.valueOf("2024-08-15"));
-
-        TypeHandlers.TIME_HANDLER.setParameter(ps, 1, Time.valueOf("12:34:56"));
-        verify(ps).setTime(1, Time.valueOf("12:34:56"));
-
-        TypeHandlers.TIMESTAMP_HANDLER.setParameter(ps, 1, Timestamp.valueOf("2024-08-15 12:34:56"));
-        verify(ps).setTimestamp(1, Timestamp.valueOf("2024-08-15 12:34:56"));
-
-        TypeHandlers.BOOLEAN_HANDLER.setParameter(ps, 1, true);
-        verify(ps).setBoolean(1, true);
     }
 
     static class InvalidClass {}

--- a/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/data/ArrowUtilsTest.java
+++ b/jdbc-core/src/test/java/com/salesforce/datacloud/jdbc/protocol/data/ArrowUtilsTest.java
@@ -17,7 +17,10 @@ import java.sql.JDBCType;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -219,5 +222,66 @@ class ArrowUtilsTest {
 
         field = schema.getFields().get(10);
         assertInstanceOf(ArrowType.List.class, field.getType());
+    }
+
+    @Test
+    void testArrowByteArrayUsesParameterEntryNames() throws Exception {
+        List<Map.Entry<String, ParameterBinding>> parameterBindings = Arrays.asList(
+                new AbstractMap.SimpleImmutableEntry<>("second", new ParameterBinding(HyperType.int32(false), 2)),
+                new AbstractMap.SimpleImmutableEntry<>("first", new ParameterBinding(HyperType.int32(false), 1)));
+
+        byte[] arrow = ArrowUtils.toArrowByteArray(parameterBindings, Calendar.getInstance());
+
+        try (org.apache.arrow.memory.RootAllocator allocator = new org.apache.arrow.memory.RootAllocator();
+                org.apache.arrow.vector.ipc.ArrowStreamReader reader =
+                        new org.apache.arrow.vector.ipc.ArrowStreamReader(
+                                new java.io.ByteArrayInputStream(arrow), allocator)) {
+            assertThat(reader.getVectorSchemaRoot().getSchema().getFields())
+                    .extracting(Field::getName)
+                    .containsExactlyInAnyOrder("second", "first");
+            assertThat(reader.loadNextBatch()).isTrue();
+            assertThat(reader.getVectorSchemaRoot().getVector("second").getObject(0))
+                    .isEqualTo(2);
+            assertThat(reader.getVectorSchemaRoot().getVector("first").getObject(0))
+                    .isEqualTo(1);
+        }
+    }
+
+    @Test
+    void testArrowByteArraySupportsTypedDecimalNull() throws Exception {
+        byte[] arrow = ArrowUtils.toArrowByteArray(
+                Collections.singletonList(new AbstractMap.SimpleImmutableEntry<>(
+                        "1", new ParameterBinding(HyperType.decimal(0, 0, true), null))),
+                Calendar.getInstance());
+
+        try (org.apache.arrow.memory.RootAllocator allocator = new org.apache.arrow.memory.RootAllocator();
+                org.apache.arrow.vector.ipc.ArrowStreamReader reader =
+                        new org.apache.arrow.vector.ipc.ArrowStreamReader(
+                                new java.io.ByteArrayInputStream(arrow), allocator)) {
+            ArrowType.Decimal decimal = (ArrowType.Decimal)
+                    reader.getVectorSchemaRoot().getSchema().getFields().get(0).getType();
+            assertThat(decimal.getPrecision()).isEqualTo(38);
+            assertThat(decimal.getScale()).isZero();
+            assertThat(reader.loadNextBatch()).isTrue();
+            assertThat(reader.getVectorSchemaRoot().getVector(0).isNull(0)).isTrue();
+        }
+    }
+
+    @Test
+    void testArrowByteArraySupportsUntypedNull() throws Exception {
+        byte[] arrow = ArrowUtils.toArrowByteArray(
+                Collections.singletonList(
+                        new AbstractMap.SimpleImmutableEntry<>("1", new ParameterBinding(HyperType.nullType(), null))),
+                Calendar.getInstance());
+
+        try (org.apache.arrow.memory.RootAllocator allocator = new org.apache.arrow.memory.RootAllocator();
+                org.apache.arrow.vector.ipc.ArrowStreamReader reader =
+                        new org.apache.arrow.vector.ipc.ArrowStreamReader(
+                                new java.io.ByteArrayInputStream(arrow), allocator)) {
+            assertThat(reader.loadNextBatch()).isTrue();
+            assertThat(reader.getVectorSchemaRoot().getVector(0))
+                    .isInstanceOf(org.apache.arrow.vector.VarCharVector.class);
+            assertThat(reader.getVectorSchemaRoot().getVector(0).isNull(0)).isTrue();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add a Hyper-specific prepared statement API for native named parameters while preserving standard JDBC positional prepared statements.

Named setters are exposed through a separate `DataCloudNamedPreparedStatement` rather than being added to `DataCloudPreparedStatement`. Hyper accepts either positional or named parameters for a query, but does not support mixing both parameter styles. Keeping them as separate statement types makes that backend constraint explicit and prevents callers from combining incompatible setters on one statement instance.

## What changed

- Add `DataCloudConnection.prepareNamedStatement(String)` returning `DataCloudNamedPreparedStatement`.
- Support named setters for the driver's existing scalar parameter types, including exact quoted names such as `:"order total"`.
- Share execution, type conversion, metadata, timeout, and parameter serialization logic between positional and named statements through a package-private base class.
- Encode named Arrow fields directly from parameter names; binding order is not significant, repeated SQL references share one binding, and rebinding replaces the value.
- Preserve typed SQL nulls where supported, encode untyped nulls compatibly with Hyper, and reject unsupported null parameter types before serialization.
- Document named parameter usage in the README.

Model: aisuite/gpt-5.6-sol · Effort: default · Co-Authored-By: Claude